### PR TITLE
fix dockerfile build

### DIFF
--- a/dlinfer/vendor/ascend/CMakeLists.txt
+++ b/dlinfer/vendor/ascend/CMakeLists.txt
@@ -8,11 +8,7 @@ execute_process(
 )
 
 execute_process(
-    COMMAND python -c "import warnings; \
-    warnings.filterwarnings('ignore', category=UserWarning, module='torch_npu'); \
-    import torch_npu; \
-    from pathlib import Path; \
-    print(str(Path(torch_npu.__file__).parent), end='')"
+    COMMAND bash -c "pip show torch-npu | awk '/^Location:/{ORS=\"\"; print \$2\"/torch_npu\"}'"
     OUTPUT_VARIABLE Torch_npu_ROOT
 )
 


### PR DESCRIPTION
Dockerfile build dlinfer from source don't have NPU resources and driver dynamic libraries in building stage, and `import torch` is failed due to lacking of certain driver library "libascend_hal.so".

So I change the way of finding existed torch_npu by `pip show torch-npu`.