### PR TITLE
[maca] add kv_cache_dtype para for context_attention_fwd func.

### DIFF
--- a/dlinfer/vendor/maca/maca_ops.py
+++ b/dlinfer/vendor/maca/maca_ops.py
@@ -280,6 +280,7 @@ def paged_prefill_attention(
         key,
         value,
         output,
+        "auto",
         key_cache,
         value_cache,
         b_loc=block_table,


### PR DESCRIPTION
add kv_cache_dtype para for context_attention_fwd func to support vllm-0.6.2.