### PR TITLE
fix state dtype and refactor gdn kernel

### DIFF
--- a/dlinfer/framework/lmdeploy_ext/device/__init__.py
+++ b/dlinfer/framework/lmdeploy_ext/device/__init__.py
@@ -404,7 +404,7 @@ def patch_gated_delta_net():
                 core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
                     q=query,
                     k=key,
-                    v=value,
+                    v=value.contiguous(),
                     g=g,
                     beta=beta,
                     initial_state=initial_state,

--- a/dlinfer/vendor/ascend/triton_ops/fla/chunk.py
+++ b/dlinfer/vendor/ascend/triton_ops/fla/chunk.py
@@ -12,12 +12,6 @@ from triton_ascend_kernels.attention.fla import chunk_gated_delta_rule_fwd
 from triton_ascend_kernels.norm.l2norm import l2norm_fwd
 
 
-def _contiguous(t):
-    if not t.is_contiguous():
-        t = t.contiguous()
-    return t
-
-
 def chunk_gated_delta_rule(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -72,14 +66,6 @@ def chunk_gated_delta_rule(
         k = l2norm_fwd(k)
 
     input_dtype = q.dtype
-    q = _contiguous(q).to(torch.bfloat16)
-    k = _contiguous(k).to(torch.bfloat16)
-    v = _contiguous(v).to(torch.bfloat16)
-    g = _contiguous(g).to(torch.bfloat16)
-    beta = _contiguous(beta).to(torch.bfloat16)
-    if initial_state is not None:
-        initial_state = _contiguous(initial_state).to(torch.bfloat16)
-
     o, final_state = chunk_gated_delta_rule_fwd(
         q=q,
         k=k,


### PR DESCRIPTION
In vllm-ascend:
varible: query key  value g beta initial_state
dtype: torch.bfloat16 torch.bfloat16 torch.bfloat16 torch.float32 torch.bfloat16 torch.float32
is_contiguous: True True True True True True
Now, these variable's dtype and is_contiguous attribute are consistent with the above in dlinfer.