### PR TITLE
[ascend] optimize gated rmsnorm

### DIFF
--- a/dlinfer/vendor/ascend/triton_ops/rms_norm_gated.py
+++ b/dlinfer/vendor/ascend/triton_ops/rms_norm_gated.py
@@ -12,6 +12,7 @@ import torch
 import torch.nn as nn
 import triton
 import triton.language as tl
+import torch.nn.functional as F
 
 MAX_CORES = 65535
 

--- a/dlinfer/vendor/ascend/triton_ops/rms_norm_gated.py
+++ b/dlinfer/vendor/ascend/triton_ops/rms_norm_gated.py
@@ -164,12 +164,7 @@ class RMSNormGated(nn.Module):
         torch.nn.init.ones_(self.weight)
 
     def forward(self, x, z=None):
-        return rmsnorm_fn(
-            x,
-            self.weight,
-            self.bias,
-            z=z,
-            eps=self.eps,
-            group_size=self.group_size,
-            norm_before_gate=self.norm_before_gate,
-        )
+        input_dtype = x.dtype
+        x = torch.ops.npu.npu_rms_norm(x, self.weight, self.eps)[0]
+        out = x * F.silu(z.to(torch.float32))
+        return out.to(input_dtype)


### PR DESCRIPTION
decoding stage, batch_size=128
old code(triton kernel):
<img width="924" height="518" alt="20260420-160531" src="https://github.com/user-attachments/assets/78a09c26-9349-488c-9ef7-3cc18f253111" />
optimize code:
<img width="738" height="515" alt="20260420-160540" src="https://github.com/user-attachments/assets/b25a493d-6cc2-460c-8c20-b578a8c8b127" />

