### PR TITLE
[Ascend] Migrate attention to FIA and unify graph updates

### DIFF
--- a/dlinfer/framework/lmdeploy_ext/cudagraph/ascend_cudagraph.py
+++ b/dlinfer/framework/lmdeploy_ext/cudagraph/ascend_cudagraph.py
@@ -1,39 +1,22 @@
 # Copyright (c) 2024, OpenMMLab and DeepLink. All rights reserved.
 # this file implements the cudagraph for ascend backend.
 import functools
-from typing import Any, Dict, List, Optional
-from dataclasses import dataclass
 from contextlib import ExitStack
-from packaging.version import InvalidVersion, Version
+from typing import Any, Dict, List
 
 import torch
-import torch_npu
 from torch import Tensor
 from torch.profiler import record_function
 
-from lmdeploy.pytorch.model_inputs import get_step_ctx_manager
-from lmdeploy.pytorch.models.utils.cudagraph import CudaGraphMeta
-from lmdeploy.pytorch.models.utils.cudagraph import CudaGraphMixin
+from lmdeploy.pytorch.backends.graph_runner import GraphRunner
 from lmdeploy.pytorch.config import BackendConfig, CacheConfig, ModelConfig
 from lmdeploy.pytorch.model_inputs import StepContext, get_step_ctx_manager
-from lmdeploy.pytorch.backends.graph_runner import GraphRunner
-
+from lmdeploy.pytorch.models.utils.cudagraph import CudaGraphMeta
+from lmdeploy.pytorch.models.utils.cudagraph import CudaGraphMixin
 from lmdeploy.utils import get_logger
 
 logger = get_logger("dlinfer")
 BuffType = Dict[str, Tensor]
-
-
-@functools.lru_cache()
-def aclgraph_use_torch_npu_update():
-    min_valid_version = Version("2.8.0.post1")
-
-    try:
-        current_version = Version(torch_npu.__version__)
-    except InvalidVersion:
-        return False
-
-    return current_version >= min_valid_version
 
 
 # AscendCudaGraphMixin methods for cudagraph buffer management.
@@ -46,7 +29,7 @@ def AscendCudaGraphMixin_support_cuda_graph(
     inputs_embeds: Tensor = None,
     **kwargs,
 ):
-    """Allow multi-token decode graph only when runtime length updates exist."""
+    """Allow decode graph after the Ascend runtime was validated at import."""
     if attn_metadata is None:
         return False
 
@@ -55,11 +38,9 @@ def AscendCudaGraphMixin_support_cuda_graph(
     # (any rank prefill => all prefill) rather than this rank's local is_decoding.
     if not get_step_ctx_manager().current_context().global_is_decoding():
         return False
-    is_decoding = getattr(attn_metadata, "is_decoding", False)
-    is_multi_token = getattr(attn_metadata, "is_multi_token_decoding", False)
-    if is_multi_token and not aclgraph_use_torch_npu_update():
-        return False
-    return is_decoding or is_multi_token
+    return getattr(attn_metadata, "is_decoding", False) or getattr(
+        attn_metadata, "is_multi_token_decoding", False
+    )
 
 
 def AscendCudaGraphMixin_make_buffers_cudagraph(
@@ -309,7 +290,6 @@ def _get_capture_batch_size_impl(max_batches: int):
     if max_batches not in ret:
         ret.append(max_batches)
 
-    set_graph_params(set(ret))
     return ret
 
 
@@ -331,7 +311,7 @@ class AscendSingleGraphRunner:
         pool: Any,
         model_config: ModelConfig,
         device: torch.device,
-        update_stream: torch.npu.Stream,
+        is_mla: bool,
     ):
         self.model = model
         self.ctx_mgr = model.ctx_mgr
@@ -356,7 +336,7 @@ class AscendSingleGraphRunner:
         self.is_decoding = is_decoding
         self.pool = pool
         self._graph: torch.npu.NPUGraph = None
-        self.update_stream = update_stream
+        self.is_mla = is_mla
 
     @record_function("capture_cudagraph")
     def capture(self, **kwargs):
@@ -373,15 +353,17 @@ class AscendSingleGraphRunner:
         warmup_buffers = self.model.make_output_buffers(warmup_output)
 
         aclgraph = torch.npu.NPUGraph()
-        with ExitStack() as stack:
-            AscendGraphRunner.capturing = True
-            with torch.npu.graph(
-                aclgraph,
-                auto_dispatch_capture=True,
-                pool=self.pool,
-                stream=current_stream,
-            ):
-                graph_output = self.model(**padded_kwargs)
+        AscendGraphRunner.capturing = True
+        try:
+            with ExitStack():
+                with torch.npu.graph(
+                    aclgraph,
+                    auto_dispatch_capture=True,
+                    pool=self.pool,
+                    stream=current_stream,
+                ):
+                    graph_output = self.model(**padded_kwargs)
+        finally:
             AscendGraphRunner.capturing = False
 
         output_buffers = self.model.make_output_buffers(graph_output)
@@ -397,21 +379,16 @@ class AscendSingleGraphRunner:
         self.model.fill_buffers_cudagraph(self.meta, **kwargs)
         context = self.ctx_mgr.current_context()
         self.model.update_context_cudagraph(self.meta, context)
-        if aclgraph_use_torch_npu_update():
-            self._graph.replay()
-            graph_params = get_graph_params()
-            if graph_params.is_mla:
-                cpu_update_input = [
-                    {"actual_seq_kvlen": self.meta.input_buffers["kv_seqlens"].tolist()}
-                ]
-            else:
-                cpu_update_input = [
-                    {"actual_seq_lengths_kv": self.meta.input_buffers["kv_seqlens"]}
-                ]
-            self._graph.update(cpu_update_input=cpu_update_input)
+        self._graph.replay()
+        if self.is_mla:
+            cpu_update_input = [
+                {"actual_seq_kvlen": self.meta.input_buffers["kv_seqlens"].tolist()}
+            ]
         else:
-            update_attn_params(self.update_stream, self.meta, self.max_batches)
-            self._graph.replay()
+            cpu_update_input = [
+                {"actual_seq_lengths_kv": self.meta.input_buffers["kv_seqlens"]}
+            ]
+        self._graph.update(cpu_update_input=cpu_update_input)
         output_buffers = self.meta.output_buffers
         output = self.model.get_outputs_cudagraph(output_buffers, **kwargs)
         return output
@@ -450,6 +427,7 @@ class AscendGraphRunner(GraphRunner):
         cache_config: CacheConfig,
         backend_config: BackendConfig,
         device: torch.device,
+        is_mla: bool = False,
     ):
         super().__init__(model, model_config, cache_config, backend_config, device)
         self.max_batches = cache_config.max_batches
@@ -459,7 +437,7 @@ class AscendGraphRunner(GraphRunner):
         self.graph_pool_handle = torch.cuda.graph_pool_handle()
         self._runner_map: Dict[Any, AscendSingleGraphRunner] = dict()
         self.has_try_compile_model: bool = False
-        self.update_stream = torch.npu.Stream()
+        self.is_mla = is_mla
 
     def check_enable_graph(self):
         """Check enable graph."""
@@ -540,7 +518,7 @@ class AscendGraphRunner(GraphRunner):
                 pool=self.graph_pool_handle,
                 model_config=self.model_config,
                 device=self.device,
-                update_stream=self.update_stream,
+                is_mla=self.is_mla,
             )
             runner.capture(**kwargs)
             self._runner_map[graph_key] = runner
@@ -565,13 +543,13 @@ class AscendGraphRunner(GraphRunner):
 
     def reset(self):
         """Remove all graphs and related resources to prevent hanging on exit."""
+        super().reset()
         for _, runner in self._runner_map.items():
             try:
                 runner.reset()
             except Exception as e:
                 logger.warning(f"AscendGraphRunner.reset: runner.reset error: {e!r}")
         self._runner_map.clear()
-        clear_graph_params()
         self.graph_pool_handle = None
         torch.npu.empty_cache()
 
@@ -600,140 +578,6 @@ class AscendGraphRunner(GraphRunner):
 
     def get_capture_batch_sizes(self) -> List[int]:
         """Capture batch sizes."""
+        if self.cache_config.cudagraph_capture_batch_sizes is not None:
+            return super().get_capture_batch_sizes()
         return _get_capture_batch_size_impl(self.cache_config.max_batches)
-
-
-@dataclass
-class GraphParams:
-    events: dict[int, list[torch.npu.ExternalEvent]]
-    workspaces: dict[int, torch.Tensor]
-    handles: dict[int, list[torch_npu._C._NPUTaskGroupHandle]]
-    attn_params: dict[int, list[tuple]]
-    is_mla: bool
-
-
-_graph_params: Optional[GraphParams] = None
-_graph_capture_sizes: set[int] = None
-
-
-def set_graph_params(aclgraph_capture_sizes: set[int]):
-    global _graph_params
-    global _graph_capture_sizes
-    if _graph_params is not None:
-        raise ValueError("Graph parameters have already been set!")
-    _graph_params = GraphParams(
-        events={size: [] for size in aclgraph_capture_sizes},
-        workspaces={size: None for size in aclgraph_capture_sizes},
-        handles={size: [] for size in aclgraph_capture_sizes},
-        attn_params={size: [] for size in aclgraph_capture_sizes},
-        is_mla=False,
-    )
-    _graph_capture_sizes = aclgraph_capture_sizes
-
-
-def get_graph_params():
-    return _graph_params
-
-
-def clear_graph_params():
-    """Clear global graph params and release references to KV cache tensors."""
-    global _graph_params
-    global _graph_capture_sizes
-    if _graph_params is None:
-        return
-
-    try:
-        for k in list(_graph_params.attn_params.keys()):
-            _graph_params.attn_params[k].clear()
-        for k in list(_graph_params.handles.keys()):
-            _graph_params.handles[k].clear()
-        for k in list(_graph_params.events.keys()):
-            _graph_params.events[k].clear()
-        _graph_params.is_mla = None
-
-        _graph_params.workspaces.clear()
-    finally:
-        _graph_params = None
-        _graph_capture_sizes = None
-        # 清除 lru_cache，使下次推理时 _get_capture_batch_size_impl
-        # 重新执行并调用 set_graph_params 干净重建
-        _get_capture_batch_size_impl.cache_clear()
-
-
-def update_attn_params(update_stream, forward_meta, runtime_size):
-    graph_params = get_graph_params()
-    for param, handle, event in zip(
-        graph_params.attn_params[runtime_size],
-        graph_params.handles[runtime_size],
-        graph_params.events[runtime_size],
-    ):
-        if graph_params.is_mla:
-            update_decode_attention_mla_params(
-                update_stream, forward_meta, param, handle, event
-            )
-        else:
-            update_decode_attention_params(
-                update_stream, forward_meta, param, handle, event
-            )
-
-
-def update_decode_attention_params(update_stream, forward_meta, param, handle, event):
-    (
-        query,
-        key_cache,
-        value_cache,
-        num_kv_heads,
-        num_heads,
-        scale,
-        block_table,
-        kv_seq_len,
-        output,
-    ) = param
-    kv_seq_len = forward_meta.input_buffers["kv_seqlens"]
-    with torch.npu.stream(update_stream):
-        torch.npu.graph_task_update_begin(update_stream, handle)
-        torch.ops.atb._npu_paged_attention(
-            query=query,
-            key_cache=key_cache,
-            value_cache=value_cache,
-            num_kv_heads=num_kv_heads,
-            num_heads=num_heads,
-            scale_value=scale,
-            block_table=block_table,
-            context_lens=kv_seq_len,
-            out=output,
-        )
-        torch.npu.graph_task_update_end(update_stream)
-        event.record(update_stream)
-
-
-def update_decode_attention_mla_params(
-    update_stream, forward_meta, param, handle, event
-):
-    (
-        query,
-        key_cache,
-        num_kv_heads,
-        num_q_heads,
-        scale_value,
-        block_table,
-        kv_seq_len,
-        mla_vheadsize,
-        attn_output,
-    ) = param
-    kv_seq_len = forward_meta.input_buffers["kv_seqlens"]
-    with torch.npu.stream(update_stream):
-        torch.npu.graph_task_update_begin(update_stream, handle)
-        torch.ops.atb._npu_paged_attention_mla(
-            query=query,
-            key_cache=key_cache,
-            num_kv_heads=num_kv_heads,
-            num_heads=num_q_heads,
-            scale_value=scale_value,
-            block_table=block_table,
-            context_lens=kv_seq_len,
-            mla_vheadsize=mla_vheadsize,
-            out=attn_output,
-        )
-        torch.npu.graph_task_update_end(update_stream)
-        event.record(update_stream)

--- a/dlinfer/framework/lmdeploy_ext/cudagraph/ascend_cudagraph.py
+++ b/dlinfer/framework/lmdeploy_ext/cudagraph/ascend_cudagraph.py
@@ -399,11 +399,16 @@ class AscendSingleGraphRunner:
         self.model.update_context_cudagraph(self.meta, context)
         if aclgraph_use_torch_npu_update():
             self._graph.replay()
-            self._graph.update(
-                cpu_update_input=[
+            graph_params = get_graph_params()
+            if graph_params.is_mla:
+                cpu_update_input = [
+                    {"actual_seq_kvlen": self.meta.input_buffers["kv_seqlens"].tolist()}
+                ]
+            else:
+                cpu_update_input = [
                     {"actual_seq_lengths_kv": self.meta.input_buffers["kv_seqlens"]}
                 ]
-            )
+            self._graph.update(cpu_update_input=cpu_update_input)
         else:
             update_attn_params(self.update_stream, self.meta, self.max_batches)
             self._graph.replay()

--- a/dlinfer/graph/dicp/dynamo_bridge/torch_version.py
+++ b/dlinfer/graph/dicp/dynamo_bridge/torch_version.py
@@ -11,6 +11,7 @@ is_torch_251 = False
 is_torch_260 = False
 is_torch_271 = False
 is_torch_280 = False
+is_torch_290 = False
 
 
 if torch_version.startswith("2.0"):
@@ -29,6 +30,8 @@ elif torch_version.startswith("2.7.1"):
     is_torch_271 = True
 elif torch_version.startswith("2.8.0"):
     is_torch_280 = True
+elif torch_version.startswith("2.9.0"):
+    is_torch_290 = True
 else:
     raise ValueError(f"unsupported dicp torch version: {torch.__version__}")
 

--- a/dlinfer/ops/llm.py
+++ b/dlinfer/ops/llm.py
@@ -419,6 +419,7 @@ def paged_prefill_attention(
         kv_scales,
         kv_zeros,
         quant_bits,
+        head_size_v,
     )
 
 

--- a/dlinfer/vendor/ascend/__init__.py
+++ b/dlinfer/vendor/ascend/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2024, DeepLink. All rights reserved.
-from pathlib import Path
+from .version import ensure_ascend_runtime
 
-import torch
-from . import pytorch_patch, torch_npu_ops
+ensure_ascend_runtime()
+
+from . import pytorch_patch, torch_npu_ops  # noqa: E402,F401

--- a/dlinfer/vendor/ascend/attention.py
+++ b/dlinfer/vendor/ascend/attention.py
@@ -2,11 +2,6 @@ import math
 import torch
 import torch_npu
 from dlinfer.utils.type_annotation import Tensor, Optional
-from dlinfer.framework.lmdeploy_ext.cudagraph.ascend_cudagraph import (
-    AscendGraphRunner,
-    get_graph_params,
-    aclgraph_use_torch_npu_update,
-)
 
 
 def decode_attention(
@@ -23,66 +18,29 @@ def decode_attention(
     softmax_scale: float,
     attn_output: Tensor,
 ):
-    if AscendGraphRunner.capturing and not aclgraph_use_torch_npu_update():
-        graph_params = get_graph_params()
-        num_tokens = query.shape[0]
-        stream = torch.npu.current_stream()
-        event = torch.npu.ExternalEvent()
-        event.wait(stream)
-        event.reset(stream)
-        graph_params.events[num_tokens].append(event)
-        graph_params.attn_params[num_tokens].append(
-            (
-                query,
-                key_cache,
-                value_cache,
-                num_kv_heads,
-                num_q_heads,
-                scale_value,
-                block_table,
-                kv_seq_len,
-                attn_output,
-            )
-        )
-        graph_params.is_mla = False
-        torch.npu.graph_task_group_begin(stream)
-        torch.ops.atb._npu_paged_attention(
-            query=query,
-            key_cache=key_cache,
-            value_cache=value_cache,
-            num_kv_heads=num_kv_heads,
-            num_heads=num_q_heads,
-            scale_value=scale_value,
-            block_table=block_table,
-            context_lens=kv_seq_len,
-            out=attn_output,
-        )
-        handle = torch.npu.graph_task_group_end(stream)
-        graph_params.handles[num_tokens].append(handle)
-    else:
-        bs, _, dim = query.shape
-        block_num = key_cache.size(0)
-        query = query.contiguous()
-        attn_output = attn_output.contiguous()
-        key_cache = key_cache.view(block_num, block_size, -1)
-        value_cache = value_cache.view(block_num, block_size, -1)
-        scale_value = softmax_scale if softmax_scale else 1.0 / math.sqrt(dim)
+    _, _, dim = query.shape
+    block_num = key_cache.size(0)
+    query = query.contiguous()
+    attn_output = attn_output.contiguous()
+    key_cache = key_cache.view(block_num, block_size, -1)
+    value_cache = value_cache.view(block_num, block_size, -1)
+    scale_value = softmax_scale if softmax_scale else 1.0 / math.sqrt(dim)
 
-        attn_output, _ = torch.ops.npu.npu_fused_infer_attention_score(
-            query=query,
-            key=key_cache,
-            value=value_cache,
-            atten_mask=None,
-            block_table=block_table,
-            input_layout="TND",
-            block_size=block_size,
-            actual_seq_lengths=q_seq_len,
-            actual_seq_lengths_kv=kv_seq_len,
-            num_key_value_heads=num_kv_heads,
-            num_heads=num_q_heads,
-            scale=scale_value,
-            sparse_mode=0,
-        )
+    attn_output, _ = torch.ops.npu.npu_fused_infer_attention_score(
+        query=query,
+        key=key_cache,
+        value=value_cache,
+        atten_mask=None,
+        block_table=block_table,
+        input_layout="TND",
+        block_size=block_size,
+        actual_seq_lengths=q_seq_len,
+        actual_seq_lengths_kv=kv_seq_len,
+        num_key_value_heads=num_kv_heads,
+        num_heads=num_q_heads,
+        scale=scale_value,
+        sparse_mode=0,
+    )
     return attn_output
 
 
@@ -97,91 +55,38 @@ def decode_attention_mla(
     mla_vheadsize: int,
     attn_output: Tensor,
 ):
-    if aclgraph_use_torch_npu_update():
-        num_tokens = query.shape[0]
-        _, block_size = key_cache.shape[:2]
+    num_tokens = query.shape[0]
+    _, block_size = key_cache.shape[:2]
 
-        q_nope = query[..., :mla_vheadsize].view(
-            num_tokens, num_q_heads, 1, mla_vheadsize
-        ).contiguous()
-        q_rope = query[..., mla_vheadsize:].view(num_tokens, num_q_heads, 1, -1)
+    q_nope = (
+        query[..., :mla_vheadsize]
+        .view(num_tokens, num_q_heads, 1, mla_vheadsize)
+        .contiguous()
+    )
+    q_rope = query[..., mla_vheadsize:].view(num_tokens, num_q_heads, 1, -1)
 
-        # FAI v2 expects paged KV cache in
-        # [block, kv_head, block_size, dim].
-        key_cache = key_cache.permute(0, 2, 1, 3)
-        k_nope = key_cache[..., :mla_vheadsize]
-        k_rope = key_cache[..., mla_vheadsize:]
+    # FIA v2 expects paged KV cache in [block, kv_head, block_size, dim].
+    key_cache = key_cache.permute(0, 2, 1, 3)
+    k_nope = key_cache[..., :mla_vheadsize]
+    k_rope = key_cache[..., mla_vheadsize:]
 
-        if AscendGraphRunner.capturing:
-            get_graph_params().is_mla = True
+    fai_output, _ = torch_npu.npu_fused_infer_attention_score_v2(
+        q_nope,
+        k_nope,
+        k_nope,
+        query_rope=q_rope,
+        key_rope=k_rope,
+        num_query_heads=num_q_heads,
+        num_key_value_heads=num_kv_heads,
+        input_layout="BNSD_NBSD",
+        atten_mask=None,
+        sparse_mode=0,
+        softmax_scale=scale_value,
+        block_table=block_table,
+        block_size=block_size,
+        actual_seq_qlen=None,
+        actual_seq_kvlen=kv_seq_len,
+    )
 
-        fai_output, _ = torch_npu.npu_fused_infer_attention_score_v2(
-            q_nope,
-            k_nope,
-            k_nope,
-            query_rope=q_rope,
-            key_rope=k_rope,
-            num_query_heads=num_q_heads,
-            num_key_value_heads=num_kv_heads,
-            input_layout="BNSD_NBSD",
-            atten_mask=None,
-            sparse_mode=0,
-            softmax_scale=scale_value,
-            block_table=block_table,
-            block_size=block_size,
-            actual_seq_qlen=None,
-            actual_seq_kvlen=kv_seq_len,
-        )
-
-        attn_output.copy_(fai_output.squeeze(2).transpose(0, 1))
-        return attn_output
-
-    if AscendGraphRunner.capturing:
-        graph_params = get_graph_params()
-        num_tokens = query.shape[0]
-        stream = torch.npu.current_stream()
-        event = torch.npu.ExternalEvent()
-        event.wait(stream)
-        event.reset(stream)
-        graph_params.events[num_tokens].append(event)
-        graph_params.attn_params[num_tokens].append(
-            (
-                query,
-                key_cache,
-                num_kv_heads,
-                num_q_heads,
-                scale_value,
-                block_table,
-                kv_seq_len,
-                mla_vheadsize,
-                attn_output,
-            )
-        )
-        graph_params.is_mla = True
-        torch.npu.graph_task_group_begin(stream)
-        torch.ops.atb._npu_paged_attention_mla(
-            query=query,
-            key_cache=key_cache,
-            num_kv_heads=num_kv_heads,
-            num_heads=num_q_heads,
-            scale_value=scale_value,
-            block_table=block_table,
-            context_lens=kv_seq_len,
-            mla_vheadsize=mla_vheadsize,
-            out=attn_output,
-        )
-        handle = torch.npu.graph_task_group_end(stream)
-        graph_params.handles[num_tokens].append(handle)
-    else:
-        torch.ops.atb._npu_paged_attention_mla(
-            query=query,
-            key_cache=key_cache,
-            num_kv_heads=num_kv_heads,
-            num_heads=num_q_heads,
-            scale_value=scale_value,
-            block_table=block_table,
-            context_lens=kv_seq_len,
-            mla_vheadsize=mla_vheadsize,
-            out=attn_output,
-        )
+    attn_output.copy_(fai_output.squeeze(2).transpose(0, 1))
     return attn_output

--- a/dlinfer/vendor/ascend/attention.py
+++ b/dlinfer/vendor/ascend/attention.py
@@ -1,5 +1,6 @@
 import math
 import torch
+import torch_npu
 from dlinfer.utils.type_annotation import Tensor, Optional
 from dlinfer.framework.lmdeploy_ext.cudagraph.ascend_cudagraph import (
     AscendGraphRunner,
@@ -96,6 +97,45 @@ def decode_attention_mla(
     mla_vheadsize: int,
     attn_output: Tensor,
 ):
+    if aclgraph_use_torch_npu_update():
+        num_tokens = query.shape[0]
+        _, block_size = key_cache.shape[:2]
+
+        q_nope = query[..., :mla_vheadsize].view(
+            num_tokens, num_q_heads, 1, mla_vheadsize
+        ).contiguous()
+        q_rope = query[..., mla_vheadsize:].view(num_tokens, num_q_heads, 1, -1)
+
+        # FAI v2 expects paged KV cache in
+        # [block, kv_head, block_size, dim].
+        key_cache = key_cache.permute(0, 2, 1, 3)
+        k_nope = key_cache[..., :mla_vheadsize]
+        k_rope = key_cache[..., mla_vheadsize:]
+
+        if AscendGraphRunner.capturing:
+            get_graph_params().is_mla = True
+
+        fai_output, _ = torch_npu.npu_fused_infer_attention_score_v2(
+            q_nope,
+            k_nope,
+            k_nope,
+            query_rope=q_rope,
+            key_rope=k_rope,
+            num_query_heads=num_q_heads,
+            num_key_value_heads=num_kv_heads,
+            input_layout="BNSD_NBSD",
+            atten_mask=None,
+            sparse_mode=0,
+            softmax_scale=scale_value,
+            block_table=block_table,
+            block_size=block_size,
+            actual_seq_qlen=None,
+            actual_seq_kvlen=kv_seq_len.tolist(),
+        )
+
+        attn_output.copy_(fai_output.squeeze(2).transpose(0, 1))
+        return attn_output
+
     if AscendGraphRunner.capturing:
         graph_params = get_graph_params()
         num_tokens = query.shape[0]

--- a/dlinfer/vendor/ascend/attention.py
+++ b/dlinfer/vendor/ascend/attention.py
@@ -130,7 +130,7 @@ def decode_attention_mla(
             block_table=block_table,
             block_size=block_size,
             actual_seq_qlen=None,
-            actual_seq_kvlen=kv_seq_len.tolist(),
+            actual_seq_kvlen=kv_seq_len,
         )
 
         attn_output.copy_(fai_output.squeeze(2).transpose(0, 1))

--- a/dlinfer/vendor/ascend/torch_npu_ops.py
+++ b/dlinfer/vendor/ascend/torch_npu_ops.py
@@ -207,11 +207,11 @@ def prefill_attention(
         actual_seq_lengths = (
             q_seq_len.cumsum(dim=0).tolist() if is_tnd else None
         )
-        fai_kwargs = {}
+        fia_kwargs = {}
         if is_tnd and query.shape[-1] > value.shape[-1]:
             nope_dim = value.shape[-1]
-            fai_kwargs["query_rope"] = query[..., nope_dim:]
-            fai_kwargs["key_rope"] = key[..., nope_dim:].contiguous()
+            fia_kwargs["query_rope"] = query[..., nope_dim:].contiguous()
+            fia_kwargs["key_rope"] = key[..., nope_dim:].contiguous()
             query = query[..., :nope_dim].contiguous()
             key = key[..., :nope_dim].contiguous()
         output, _ = torch_npu.npu_fused_infer_attention_score(
@@ -225,7 +225,7 @@ def prefill_attention(
             num_heads=num_q_heads,
             num_key_value_heads=num_kv_heads,
             sparse_mode=0,
-            **fai_kwargs,
+            **fia_kwargs,
         )
         attn_output.copy_(output)
         return attn_output
@@ -233,20 +233,15 @@ def prefill_attention(
         q_seq_len = get_cpu_seq_len(q_seq_len)
         actual_seq_lengths = q_seq_len.cumsum(dim=0).tolist()
 
-        # With different QK and V head dimensions, FAI v1 requires a
-        # B1S1S2 attention mask in sparse mode 0. Expand is a zero-copy view.
-        if mask.dim() == 2:
-            mask = mask.to(torch.bool)[None, None].expand(
-                q_seq_len.numel(), 1, -1, -1
-            )
-
-        fai_kwargs = {}
+        # The backend supplies the fixed split-fuse causal mask required by
+        # sparse mode 3 for both standard attention and MLA.
+        fia_kwargs = {}
         if query.shape[-1] > value.shape[-1]:
-            # MLA concatenates the NOPE and ROPE parts in Q/K. FAI accepts
+            # MLA concatenates the NOPE and ROPE parts in Q/K. FIA accepts
             # large MLA head dimensions only when the ROPE part is separate.
             nope_dim = value.shape[-1]
-            fai_kwargs["query_rope"] = query[..., nope_dim:]
-            fai_kwargs["key_rope"] = key[..., nope_dim:].contiguous()
+            fia_kwargs["query_rope"] = query[..., nope_dim:].contiguous()
+            fia_kwargs["key_rope"] = key[..., nope_dim:].contiguous()
             query = query[..., :nope_dim].contiguous()
             key = key[..., :nope_dim].contiguous()
 
@@ -261,8 +256,8 @@ def prefill_attention(
             scale=scale_value,
             num_heads=num_q_heads,
             num_key_value_heads=num_kv_heads,
-            sparse_mode=0,
-            **fai_kwargs,
+            sparse_mode=3,
+            **fia_kwargs,
         )
         attn_output.copy_(output)
     elif SocVersion.is_Ascend310P():

--- a/dlinfer/vendor/ascend/torch_npu_ops.py
+++ b/dlinfer/vendor/ascend/torch_npu_ops.py
@@ -208,9 +208,7 @@ def prefill_attention(
             and key.shape[-2] == num_kv_heads
         )
         input_layout = "TND" if is_tnd else "BSH"
-        actual_seq_lengths = (
-            q_seq_len.cumsum(dim=0).tolist() if is_tnd else None
-        )
+        actual_seq_lengths = q_seq_len.cumsum(dim=0) if is_tnd else None
         fia_kwargs = {}
         if is_tnd and query.shape[-1] > value.shape[-1]:
             nope_dim = value.shape[-1]
@@ -235,7 +233,7 @@ def prefill_attention(
         return attn_output
     if SocVersion.is_Ascend910():
         q_seq_len = get_cpu_seq_len(q_seq_len)
-        actual_seq_lengths = q_seq_len.cumsum(dim=0).tolist()
+        actual_seq_lengths = q_seq_len.cumsum(dim=0)
 
         # The backend supplies the fixed split-fuse causal mask required by
         # sparse mode 3 for both standard attention and MLA.
@@ -548,8 +546,8 @@ def paged_prefill_attention(
             softmax_scale=scale_value,
             block_table=block_table,
             block_size=block_size,
-            actual_seq_qlen=q_seq_len.tolist(),
-            actual_seq_kvlen=kv_seq_len.tolist(),
+            actual_seq_qlen=q_seq_len,
+            actual_seq_kvlen=kv_seq_len,
         )
 
         # TND_NTD returns [num_heads, num_tokens, value_head_size].

--- a/dlinfer/vendor/ascend/torch_npu_ops.py
+++ b/dlinfer/vendor/ascend/torch_npu_ops.py
@@ -6,10 +6,6 @@ import torch_npu
 
 from typing import List
 from dlinfer.vendor import vendor_ops_registry
-from dlinfer.framework.lmdeploy_ext.cudagraph.ascend_cudagraph import (
-    AscendGraphRunner,
-    get_graph_params,
-)
 from dlinfer.utils.registry import register_ops
 from dlinfer.utils.type_annotation import (
     Tensor,
@@ -262,20 +258,6 @@ def prefill_attention(
             **fia_kwargs,
         )
         attn_output.copy_(output)
-    elif SocVersion.is_Ascend310P():
-        # Used for Qwen2.5-VL model vision block
-        query = query.unsqueeze(0)
-        key = key.unsqueeze(0)
-        value = value.unsqueeze(0)
-        attn_output[:] = torch.ops.npu.npu_prompt_flash_attention(
-            query,
-            key,
-            value,
-            num_heads=num_q_heads,
-            num_key_value_heads=num_kv_heads,
-            input_layout="BSND",
-            scale_value=scale_value,
-        )
     else:
         raise ValueError(
             f"dlinfer doesn't support {SocVersion.device_name()} device currently."
@@ -528,9 +510,6 @@ def paged_prefill_attention(
         k_rope = key_cache[..., mla_vheadsize:]
         v_nope = value_cache[..., :mla_vheadsize]
         mask = attn_mask[0] if len(attn_mask) else None
-
-        if AscendGraphRunner.capturing:
-            get_graph_params().is_mla = True
 
         output, _ = torch_npu.npu_fused_infer_attention_score_v2(
             q_nope,

--- a/dlinfer/vendor/ascend/torch_npu_ops.py
+++ b/dlinfer/vendor/ascend/torch_npu_ops.py
@@ -2,6 +2,7 @@
 import math
 import torch
 import torch.distributed as dist
+import torch_npu
 
 from typing import List
 from dlinfer.vendor import vendor_ops_registry
@@ -197,29 +198,73 @@ def prefill_attention(
     else:
         # Handle qwenvl vision part flash-attention
         q_seq_len = get_cpu_seq_len(q_seq_len)
-        torch.ops.atb._npu_flash_attention_unpad(
+        is_tnd = (
+            query.dim() == 3
+            and query.shape[-2] == num_q_heads
+            and key.shape[-2] == num_kv_heads
+        )
+        input_layout = "TND" if is_tnd else "BSH"
+        actual_seq_lengths = (
+            q_seq_len.cumsum(dim=0).tolist() if is_tnd else None
+        )
+        fai_kwargs = {}
+        if is_tnd and query.shape[-1] > value.shape[-1]:
+            nope_dim = value.shape[-1]
+            fai_kwargs["query_rope"] = query[..., nope_dim:]
+            fai_kwargs["key_rope"] = key[..., nope_dim:].contiguous()
+            query = query[..., :nope_dim].contiguous()
+            key = key[..., :nope_dim].contiguous()
+        output, _ = torch_npu.npu_fused_infer_attention_score(
             query=query,
             key=key,
             value=value,
-            seq_len=q_seq_len,
-            scale_value=scale_value,
+            input_layout=input_layout,
+            actual_seq_lengths=actual_seq_lengths,
+            actual_seq_lengths_kv=actual_seq_lengths,
+            scale=scale_value,
             num_heads=num_q_heads,
-            num_kv_heads=num_kv_heads,
-            out=attn_output,
+            num_key_value_heads=num_kv_heads,
+            sparse_mode=0,
+            **fai_kwargs,
         )
+        attn_output.copy_(output)
         return attn_output
     if SocVersion.is_Ascend910():
-        torch.ops.atb._npu_flash_attention(
+        q_seq_len = get_cpu_seq_len(q_seq_len)
+        actual_seq_lengths = q_seq_len.cumsum(dim=0).tolist()
+
+        # With different QK and V head dimensions, FAI v1 requires a
+        # B1S1S2 attention mask in sparse mode 0. Expand is a zero-copy view.
+        if mask.dim() == 2:
+            mask = mask.to(torch.bool)[None, None].expand(
+                q_seq_len.numel(), 1, -1, -1
+            )
+
+        fai_kwargs = {}
+        if query.shape[-1] > value.shape[-1]:
+            # MLA concatenates the NOPE and ROPE parts in Q/K. FAI accepts
+            # large MLA head dimensions only when the ROPE part is separate.
+            nope_dim = value.shape[-1]
+            fai_kwargs["query_rope"] = query[..., nope_dim:]
+            fai_kwargs["key_rope"] = key[..., nope_dim:].contiguous()
+            query = query[..., :nope_dim].contiguous()
+            key = key[..., :nope_dim].contiguous()
+
+        output, _ = torch_npu.npu_fused_infer_attention_score(
             query=query,
             key=key,
             value=value,
-            mask=mask,
-            seq_len=q_seq_len,
-            scale_value=scale_value,
+            atten_mask=mask,
+            input_layout="TND",
+            actual_seq_lengths=actual_seq_lengths,
+            actual_seq_lengths_kv=actual_seq_lengths,
+            scale=scale_value,
             num_heads=num_q_heads,
-            num_kv_heads=num_kv_heads,
-            out=attn_output,
+            num_key_value_heads=num_kv_heads,
+            sparse_mode=0,
+            **fai_kwargs,
         )
+        attn_output.copy_(output)
     elif SocVersion.is_Ascend310P():
         # Used for Qwen2.5-VL model vision block
         query = query.unsqueeze(0)

--- a/dlinfer/vendor/ascend/torch_npu_ops.py
+++ b/dlinfer/vendor/ascend/torch_npu_ops.py
@@ -6,6 +6,10 @@ import torch_npu
 
 from typing import List
 from dlinfer.vendor import vendor_ops_registry
+from dlinfer.framework.lmdeploy_ext.cudagraph.ascend_cudagraph import (
+    AscendGraphRunner,
+    get_graph_params,
+)
 from dlinfer.utils.registry import register_ops
 from dlinfer.utils.type_annotation import (
     Tensor,
@@ -488,19 +492,78 @@ def paged_prefill_attention(
     kv_scales: Optional[Tensor],
     kv_zeros: Optional[Tensor],
     quant_bits: Optional[int],
+    head_size_v: Optional[int] = None,
 ) -> Tensor:
     if alibi_slopes is not None:
         raise RuntimeError(
             "paged_decode_attention does not " "support alibi_slopes yet"
         )
 
+    if isinstance(block_table, torch.Tensor) and block_table.dtype != torch.int32:
+        block_table = block_table.to(torch.int32)
+
     scale_value = softmax_scale if softmax_scale else 1.0 / math.sqrt(query.shape[-1])
     query = query.contiguous()
+
+    # lmdeploy's DeepSeek MLA path absorbs W_UK into Q. Its paged cache is
+    # therefore [latent K/V, RoPE K], while value_cache is a view of the
+    # latent part. Follow vllm-ascend's multi-token paged attention path:
+    # feed the latent and RoPE components separately to FIA v2, and use the
+    # split-fuse causal mask with sparse mode 3.
+    is_mla = key_cache.shape[-1] != value_cache.shape[-1]
+    if is_mla:
+        num_tokens = query.shape[0]
+        mla_vheadsize = head_size_v or value_cache.shape[-1]
+        if query.shape[-1] <= mla_vheadsize:
+            raise RuntimeError(
+                "MLA paged prefill expects query to contain both latent and RoPE parts"
+            )
+
+        q_nope = query[..., :mla_vheadsize].contiguous()
+        q_rope = query[..., mla_vheadsize:].contiguous()
+
+        # FIA v2 expects paged KV cache in
+        # [block, kv_head, block_size, dim].
+        key_cache = key_cache.permute(0, 2, 1, 3)
+        value_cache = value_cache.permute(0, 2, 1, 3)
+        k_nope = key_cache[..., :mla_vheadsize]
+        k_rope = key_cache[..., mla_vheadsize:]
+        v_nope = value_cache[..., :mla_vheadsize]
+        mask = attn_mask[0] if len(attn_mask) else None
+
+        if AscendGraphRunner.capturing:
+            get_graph_params().is_mla = True
+
+        output, _ = torch_npu.npu_fused_infer_attention_score_v2(
+            q_nope,
+            k_nope,
+            v_nope,
+            query_rope=q_rope,
+            key_rope=k_rope,
+            num_query_heads=num_q_heads,
+            num_key_value_heads=num_kv_heads,
+            input_layout="TND_NTD",
+            atten_mask=mask,
+            sparse_mode=3,
+            softmax_scale=scale_value,
+            block_table=block_table,
+            block_size=block_size,
+            actual_seq_qlen=q_seq_len.tolist(),
+            actual_seq_kvlen=kv_seq_len.tolist(),
+        )
+
+        # TND_NTD returns [num_heads, num_tokens, value_head_size].
+        output = output[:, :num_tokens].transpose(0, 1)
+        if attn_output is not None:
+            attn_output.copy_(output)
+            return attn_output
+        return output
+
     block_num = key_cache.size(0)
     key_cache = key_cache.view(block_num, block_size, -1)
     value_cache = value_cache.view(block_num, block_size, -1)
 
-    attn_output, _ = torch.ops.npu.npu_fused_infer_attention_score(
+    output, _ = torch.ops.npu.npu_fused_infer_attention_score(
         query=query,
         key=key_cache,
         value=value_cache,
@@ -516,7 +579,10 @@ def paged_prefill_attention(
         sparse_mode=3,
     )
 
-    return attn_output
+    if attn_output is not None:
+        attn_output.copy_(output)
+        return attn_output
+    return output
 
 
 @register_ops(vendor_ops_registry)

--- a/dlinfer/vendor/ascend/version.py
+++ b/dlinfer/vendor/ascend/version.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, DeepLink. All rights reserved.
+
+from typing import Optional
+
+from packaging.version import InvalidVersion, Version
+import torch
+import torch_npu
+
+MIN_TORCH_VERSION = Version("2.8.0")
+MIN_TORCH_NPU_VERSION = Version("2.8.0.post1")
+
+
+def _parse_version(raw_version: str, package_name: str) -> Version:
+    try:
+        return Version(raw_version)
+    except InvalidVersion as exc:
+        raise RuntimeError(
+            f"Invalid {package_name} version {raw_version!r}; DLINFER Ascend requires "
+            f"torch>={MIN_TORCH_VERSION} and torch-npu>={MIN_TORCH_NPU_VERSION}."
+        ) from exc
+
+
+def ensure_ascend_runtime(
+    torch_version: Optional[str] = None,
+    torch_npu_version: Optional[str] = None,
+    check_graph_api: bool = True,
+) -> tuple[Version, Version]:
+    """Validate the only supported Ascend graph-update runtime path."""
+    parsed_torch = _parse_version(
+        torch.__version__ if torch_version is None else torch_version, "torch"
+    )
+    parsed_torch_npu = _parse_version(
+        torch_npu.__version__ if torch_npu_version is None else torch_npu_version,
+        "torch-npu",
+    )
+
+    if parsed_torch < MIN_TORCH_VERSION:
+        raise RuntimeError(
+            f"Unsupported torch version {parsed_torch}; DLINFER Ascend requires "
+            f"torch>={MIN_TORCH_VERSION}. The legacy ATB graph-task update path "
+            "has been removed."
+        )
+    if parsed_torch_npu < MIN_TORCH_NPU_VERSION:
+        raise RuntimeError(
+            f"Unsupported torch-npu version {parsed_torch_npu}; DLINFER Ascend "
+            f"requires torch-npu>={MIN_TORCH_NPU_VERSION}. The legacy ATB "
+            "graph-task update path has been removed."
+        )
+    if parsed_torch.release[:2] != parsed_torch_npu.release[:2]:
+        raise RuntimeError(
+            "torch and torch-npu must use the same major.minor release for the "
+            f"Ascend backend, but got torch {parsed_torch} and torch-npu "
+            f"{parsed_torch_npu}."
+        )
+
+    graph_cls = getattr(getattr(torch, "npu", None), "NPUGraph", None)
+    if check_graph_api and not callable(getattr(graph_cls, "update", None)):
+        raise RuntimeError(
+            "torch.npu.NPUGraph.update is unavailable. DLINFER Ascend graph mode "
+            f"requires torch>={MIN_TORCH_VERSION} and "
+            f"torch-npu>={MIN_TORCH_NPU_VERSION}."
+        )
+
+    return parsed_torch, parsed_torch_npu

--- a/dlinfer/vendor/camb/camb_ops.py
+++ b/dlinfer/vendor/camb/camb_ops.py
@@ -278,6 +278,7 @@ def paged_prefill_attention(
     kv_scales: Optional[Tensor],
     kv_zeros: Optional[Tensor],
     quant_bits: Optional[int],
+    head_size_v: Optional[int] = None,
 ) -> Tensor:
     if softmax_scale is None:
         softmax_scale = float(1 / math.sqrt(query.size(-1)))

--- a/dlinfer/vendor/maca/maca_ops.py
+++ b/dlinfer/vendor/maca/maca_ops.py
@@ -294,6 +294,7 @@ def paged_prefill_attention(
     kv_scales: Optional[Tensor],
     kv_zeros: Optional[Tensor],
     quant_bits: Optional[int],
+    head_size_v: Optional[int] = None,
 ) -> Tensor:
     if softmax_scale is None:
         softmax_scale = float(1 / math.sqrt(query.size(-1)))

--- a/docs/ascend_cudagraph_rl_lifecycle.md
+++ b/docs/ascend_cudagraph_rl_lifecycle.md
@@ -11,7 +11,9 @@ _graph_capture_sizes: set[int] = None
 
 - `_graph_params` 历史上保存旧版 Attention graph-task 更新所需的图资源，必须在 rollout reset 时清理。
 - `_graph_capture_sizes` 当前只有赋值和清空，没有任何读取位置，因此没有实际控制作用。
-- RL re-capture 修复真正依赖的是 `_get_capture_batch_size_impl.cache_clear()`，而不是 `_graph_capture_sizes` 变量本身。
+- RL re-capture 修复真正依赖的是
+  `_get_capture_batch_size_impl.cache_clear()`，而不是
+  `_graph_capture_sizes` 变量本身。
 - “capture size 需要跨 rollout 保存”指 capture-size 策略或配置，不是旧图的 handle、event 和 Tensor 引用。
 
 > 实现状态（2026-08-17）：本文第 6 节的重构已经落地。旧 ATB
@@ -20,7 +22,9 @@ _graph_capture_sizes: set[int] = None
 
 ## 1. `_graph_params` 的历史用途
 
-`_graph_params` 最早在提交 [`5c474737`](https://github.com/DeepLink-org/dlinfer/commit/5c4747371b6bd3f39a71656c74e99e3429f259d1) 中引入，用于支持旧版 ATB Attention 的 graph-task 动态参数更新：
+`_graph_params` 最早在提交
+[`5c474737`](https://github.com/DeepLink-org/dlinfer/commit/5c4747371b6bd3f39a71656c74e99e3429f259d1)
+中引入，用于支持旧版 ATB Attention 的 graph-task 动态参数更新：
 
 ```python
 @dataclass
@@ -66,7 +70,9 @@ torch.ops.atb._npu_paged_attention(...)
 torch.npu.graph_task_update_end(...)
 ```
 
-因此，`_graph_params` 本质上是旧 ATB Attention kernel 与 Graph Runner 之间的全局 side channel。它不是普通配置元信息，而是持有真实图资源和 Tensor 引用的对象。
+因此，`_graph_params` 本质上是旧 ATB Attention kernel 与 Graph
+Runner 之间的全局 side channel。它不是普通配置元信息，而是持有真实图资源和
+Tensor 引用的对象。
 
 ## 2. 为什么 rollout 之间必须清理 `_graph_params`
 
@@ -90,7 +96,9 @@ rollout N 推理
 
 所以 `_graph_params` 不能跨 rollout 复用。
 
-提交 [`d0f60279`](https://github.com/DeepLink-org/dlinfer/commit/d0f60279a684de7dd37f0cab59d5065747faf598) 为此增加了 `clear_graph_params()`：
+提交
+[`d0f60279`](https://github.com/DeepLink-org/dlinfer/commit/d0f60279a684de7dd37f0cab59d5065747faf598)
+为此增加了 `clear_graph_params()`：
 
 ```python
 attn_params.clear()
@@ -172,7 +180,9 @@ get_graph_params().events[...]
 
 ## 4. `_graph_capture_sizes` 的实际作用
 
-`_graph_capture_sizes` 由 [`PR #319: fix re-capture in RL`](https://github.com/DeepLink-org/dlinfer/pull/319) 引入：
+`_graph_capture_sizes` 由
+[`PR #319: fix re-capture in RL`](https://github.com/DeepLink-org/dlinfer/pull/319)
+引入：
 
 ```python
 _graph_capture_sizes: set[int] = None
@@ -198,7 +208,9 @@ _get_capture_batch_size_impl.cache_clear()
 - 赋值；
 - 清空。
 
-代码中没有读取它的 getter，也没有用它重新初始化 `GraphParams`。因此，按照当前实现，`_graph_capture_sizes` 是一个冗余的 bookkeeping 变量，对 re-capture 没有功能性贡献。
+代码中没有读取它的 getter，也没有用它重新初始化 `GraphParams`。因此，按照当前实现，
+`_graph_capture_sizes` 是一个冗余的 bookkeeping 变量，对 re-capture
+没有功能性贡献。
 
 PR #319 真正修复问题的是：
 
@@ -227,7 +239,9 @@ CacheConfig.max_batches
 CacheConfig.cudagraph_capture_batch_sizes
 ```
 
-LMDeploy 后来在提交 [`4f25485e`](https://github.com/InternLM/lmdeploy/commit/4f25485e218d5e0938240da1d4fccbb426573a89) 中正式把 capture sizes 放进了 `CacheConfig`：
+LMDeploy 后来在提交
+[`4f25485e`](https://github.com/InternLM/lmdeploy/commit/4f25485e218d5e0938240da1d4fccbb426573a89)
+中正式把 capture sizes 放进了 `CacheConfig`：
 
 ```python
 cudagraph_capture_batch_sizes: list[int] | None
@@ -311,6 +325,7 @@ inference
 最终可以删除 `_graph_params` 和 `_graph_capture_sizes`，但必须保留它们背后的两类语义：
 
 - `_graph_params` 背后的旧图资源生命周期：新路径中由每个 `NPUGraph` 自己管理，并在 reset 时释放。
-- `_graph_capture_sizes` 名字所暗示的 capture-size 策略：迁移到持久的 `CacheConfig`，不能随着 rollout 丢失。
+- `_graph_capture_sizes` 名字所暗示的 capture-size 策略：迁移到持久的
+  `CacheConfig`，不能随着 rollout 丢失。
 
 换句话说，需要保留的是生命周期语义和配置来源，而不是这两个模块级全局变量本身。

--- a/docs/ascend_cudagraph_rl_lifecycle.md
+++ b/docs/ascend_cudagraph_rl_lifecycle.md
@@ -1,0 +1,316 @@
+# Ascend CUDAGraph 全局状态与 RL Re-capture 生命周期
+
+本文说明 DLINFER Ascend CUDAGraph 实现中以下两个全局变量的历史用途、生命周期，以及它们与 RL rollout re-capture 的关系：
+
+```python
+_graph_params: Optional[GraphParams] = None
+_graph_capture_sizes: set[int] = None
+```
+
+核心结论如下：
+
+- `_graph_params` 历史上保存旧版 Attention graph-task 更新所需的图资源，必须在 rollout reset 时清理。
+- `_graph_capture_sizes` 当前只有赋值和清空，没有任何读取位置，因此没有实际控制作用。
+- RL re-capture 修复真正依赖的是 `_get_capture_batch_size_impl.cache_clear()`，而不是 `_graph_capture_sizes` 变量本身。
+- “capture size 需要跨 rollout 保存”指 capture-size 策略或配置，不是旧图的 handle、event 和 Tensor 引用。
+
+> 实现状态（2026-08-17）：本文第 6 节的重构已经落地。旧 ATB
+> graph-task 路径以及 `_graph_params`、`_graph_capture_sizes` 已删除；
+> capture-size 计算已成为纯函数，显式配置由 `CacheConfig` 跨 rollout 保存。
+
+## 1. `_graph_params` 的历史用途
+
+`_graph_params` 最早在提交 [`5c474737`](https://github.com/DeepLink-org/dlinfer/commit/5c4747371b6bd3f39a71656c74e99e3429f259d1) 中引入，用于支持旧版 ATB Attention 的 graph-task 动态参数更新：
+
+```python
+@dataclass
+class GraphParams:
+    events: dict[int, list[torch.npu.ExternalEvent]]
+    workspaces: dict[int, torch.Tensor]
+    handles: dict[int, list[NPUTaskGroupHandle]]
+    attn_params: dict[int, list[tuple]]
+    is_mla: bool
+```
+
+其中的字典以 capture size 为 key。例如捕获 batch size 8 的图时，对应资源存放在：
+
+```python
+events[8]
+handles[8]
+attn_params[8]
+```
+
+Attention capture 期间，每一层会注册以下信息：
+
+- Attention 输入 Tensor；
+- KV cache Tensor；
+- `block_table`；
+- `kv_seq_len`；
+- 输出 Tensor；
+- graph-task handle；
+- 同步 event。
+
+旧版 replay 时，Graph Runner 根据当前 graph size 找到这些对象：
+
+```python
+graph_params.attn_params[runtime_size]
+graph_params.handles[runtime_size]
+graph_params.events[runtime_size]
+```
+
+随后通过低层 graph-task API 更新 Attention 的运行时参数：
+
+```python
+torch.npu.graph_task_update_begin(...)
+torch.ops.atb._npu_paged_attention(...)
+torch.npu.graph_task_update_end(...)
+```
+
+因此，`_graph_params` 本质上是旧 ATB Attention kernel 与 Graph Runner 之间的全局 side channel。它不是普通配置元信息，而是持有真实图资源和 Tensor 引用的对象。
+
+## 2. 为什么 rollout 之间必须清理 `_graph_params`
+
+RL rollout 的典型生命周期如下：
+
+```text
+rollout N 推理
+  -> sleep / 更新权重
+  -> reset graph
+  -> wakeup
+  -> rollout N+1 重新 capture
+```
+
+模型 sleep 或更新权重后：
+
+- 原权重 Tensor 地址可能发生变化；
+- KV cache 可能被释放或重新分配；
+- captured graph 中保存的输入输出地址可能已经失效；
+- ATB task handle 和 event 属于旧图；
+- `attn_params` 中保存的 Tensor 引用会阻止显存释放。
+
+所以 `_graph_params` 不能跨 rollout 复用。
+
+提交 [`d0f60279`](https://github.com/DeepLink-org/dlinfer/commit/d0f60279a684de7dd37f0cab59d5065747faf598) 为此增加了 `clear_graph_params()`：
+
+```python
+attn_params.clear()
+handles.clear()
+events.clear()
+workspaces.clear()
+_graph_params = None
+```
+
+如果错误地保留 `_graph_params`，可能导致：
+
+- 显存泄漏；
+- 使用旧 KV cache 地址；
+- 使用已失效的权重地址；
+- graph replay 卡住；
+- 权重更新后仍得到旧结果。
+
+从生命周期上可以把状态分成两类：
+
+```text
+应该跨 rollout 保存：
+    capture-size 策略、max_batches、模型类型
+
+不应该跨 rollout 保存：
+    NPUGraph、task handle、event、Tensor 引用、output buffer
+```
+
+## 3. RL re-capture 问题的根因
+
+历史实现把 capture-size 计算和 `_graph_params` 初始化放进了同一个带缓存函数：
+
+```python
+@functools.lru_cache
+def _get_capture_batch_size_impl(max_batches):
+    ...
+    set_graph_params(set(ret))
+    return ret
+```
+
+这里混合了两种不同职责：
+
+1. 计算 capture sizes；
+2. 初始化 `_graph_params`。
+
+第一次 rollout 使用 `max_batches=256` 时：
+
+```text
+_get_capture_batch_size_impl(256)
+  -> 函数体执行
+  -> set_graph_params(...)
+  -> lru_cache 保存返回值
+```
+
+sleep/reset 时：
+
+```text
+clear_graph_params()
+  -> _graph_params = None
+```
+
+第二次 rollout 仍使用 `max_batches=256` 时：
+
+```text
+_get_capture_batch_size_impl(256)
+  -> 命中 lru_cache
+  -> 直接返回 capture-size 列表
+  -> 函数体不执行
+  -> set_graph_params() 没有再次调用
+  -> _graph_params 仍是 None
+```
+
+接下来 Attention capture 如果执行：
+
+```python
+get_graph_params().events[...]
+```
+
+就会访问 `None`。这才是 re-capture 问题的根因。
+
+## 4. `_graph_capture_sizes` 的实际作用
+
+`_graph_capture_sizes` 由 [`PR #319: fix re-capture in RL`](https://github.com/DeepLink-org/dlinfer/pull/319) 引入：
+
+```python
+_graph_capture_sizes: set[int] = None
+```
+
+初始化时进行赋值：
+
+```python
+_graph_capture_sizes = aclgraph_capture_sizes
+```
+
+清理时执行：
+
+```python
+_graph_capture_sizes = None
+_get_capture_batch_size_impl.cache_clear()
+```
+
+检查该 PR 的提交快照、当前开发分支和 `origin/main` 后可以确认，`_graph_capture_sizes` 只有以下操作：
+
+- 声明；
+- `global` 引用；
+- 赋值；
+- 清空。
+
+代码中没有读取它的 getter，也没有用它重新初始化 `GraphParams`。因此，按照当前实现，`_graph_capture_sizes` 是一个冗余的 bookkeeping 变量，对 re-capture 没有功能性贡献。
+
+PR #319 真正修复问题的是：
+
+```python
+_get_capture_batch_size_impl.cache_clear()
+```
+
+它保证下一次 rollout 即使使用相同的 `max_batches`，函数体也会重新执行，并再次调用 `set_graph_params()`。
+
+该 PR 没有正文和讨论，只有 8 行修改。因此无法从历史材料证明作者计划在其他地方读取 `_graph_capture_sizes`；从现有代码只能确认它没有参与任何控制逻辑。
+
+## 5. 如何理解“capture size 要跨 rollout 保存”
+
+这里的 capture size 应当理解为 engine 需要捕获哪些 batch size，例如：
+
+```text
+[1, 2, 4, 8, 16, 32]
+```
+
+这是配置或 shape policy，应该跨 rollout 保留，因为它决定 wakeup 后需要重新捕获哪些图。
+
+但它不等同于 `_graph_capture_sizes` 这个全局变量。更合理的持久化来源是：
+
+```python
+CacheConfig.max_batches
+CacheConfig.cudagraph_capture_batch_sizes
+```
+
+LMDeploy 后来在提交 [`4f25485e`](https://github.com/InternLM/lmdeploy/commit/4f25485e218d5e0938240da1d4fccbb426573a89) 中正式把 capture sizes 放进了 `CacheConfig`：
+
+```python
+cudagraph_capture_batch_sizes: list[int] | None
+```
+
+合理的状态归属如下：
+
+```text
+CacheConfig                         跨 rollout 保留
+    `-- cudagraph_capture_batch_sizes
+
+AscendGraphRunner                   rollout 之间 reset
+    `-- _runner_map
+          `-- AscendSingleGraphRunner
+                `-- NPUGraph
+
+旧版全局 _graph_params             rollout 之间销毁
+    |-- handles
+    |-- events
+    `-- Tensor refs
+```
+
+重构后的 Ascend DLINFER `get_capture_batch_sizes()` 会优先读取 LMDeploy 的
+`CacheConfig.cudagraph_capture_batch_sizes`；未显式配置时，才调用 Ascend 的
+`_get_capture_batch_size_impl()` 生成默认尺寸。
+
+## 6. 本次重构结果
+
+本次重构没有只做以下机械删除：
+
+```text
+删除 _graph_params
+删除 _graph_capture_sizes
+删除 cache_clear()
+```
+
+同时完成了以下生命周期迁移：
+
+1. capture-size 计算已经成为纯函数：
+
+   ```python
+   @functools.lru_cache
+   def _get_capture_batch_size_impl(max_batches):
+       ...
+       return ret
+   ```
+
+   其中不能再调用 `set_graph_params()`。
+
+2. capture-size 策略保存在 `CacheConfig` 中，可以跨 rollout 保留。
+3. `op_backend.py` 根据 K/V head dim 显式判断并向 Graph Runner 传递 `is_mla`。
+4. Dense decode 固定使用 FIA，MLA decode 和 paged prefill 固定使用 FIA v2。
+5. Graph replay 固定使用 `NPUGraph.update()`；旧 ATB graph-task Attention 路径已删除。
+6. `_graph_params` 和从未被读取的 `_graph_capture_sizes` 已整体删除。
+7. `AscendGraphRunner.reset()` 先调用基类 reset，清空 rollout 局部的
+   `padding_batch_size`，但不清除 `CacheConfig` 中的 capture sizes。
+8. 增加 capture-size 纯函数、reset 配置保留、FIA v2 graph replay 和版本门槛测试。
+
+完整 RL 场景仍建议执行以下端到端回归：
+
+```text
+capture -> inference
+reset/sleep
+wakeup
+使用相同 max_batches 再次 capture
+inference
+重复两到三轮
+```
+
+测试需要验证：
+
+- 不出现 `_graph_params is None`；
+- 不使用旧权重；
+- 不持有旧 KV cache；
+- capture sizes 与第一次一致；
+- graph replay 精度正确；
+- 多轮 sleep/wakeup 后没有显存持续增长。
+
+## 7. 最终结论
+
+最终可以删除 `_graph_params` 和 `_graph_capture_sizes`，但必须保留它们背后的两类语义：
+
+- `_graph_params` 背后的旧图资源生命周期：新路径中由每个 `NPUGraph` 自己管理，并在 reset 时释放。
+- `_graph_capture_sizes` 名字所暗示的 capture-size 策略：迁移到持久的 `CacheConfig`，不能随着 rollout 丢失。
+
+换句话说，需要保留的是生命周期语义和配置来源，而不是这两个模块级全局变量本身。

--- a/requirements/ascend/torch.txt
+++ b/requirements/ascend/torch.txt
@@ -1,6 +1,7 @@
 # Please install one of the supported versions manually
-torch>=2.3.1,<2.10.0
-torch-npu>=2.3.1,<2.10.0
-torchvision>=0.18.1,<0.25.0
+torch>=2.8.0,<2.10.0
+torch-npu>=2.8.0.post1,<2.10.0
+torchvision>=0.23.0,<0.25.0
 importlib-metadata
+packaging
 pyyaml

--- a/tests/test_ascend_attention_precision.py
+++ b/tests/test_ascend_attention_precision.py
@@ -12,13 +12,6 @@ pytestmark = pytest.mark.lmdeploy
 if not torch.npu.is_available():
     pytest.skip("Ascend NPU is required", allow_module_level=True)
 
-from dlinfer.framework.lmdeploy_ext.cudagraph.ascend_cudagraph import (
-    AscendGraphRunner,
-    aclgraph_use_torch_npu_update,
-    clear_graph_params,
-    get_graph_params,
-    set_graph_params,
-)
 from dlinfer.ops import paged_prefill_attention
 from dlinfer.vendor.ascend.attention import decode_attention_mla
 from dlinfer.vendor.ascend.torch_npu_ops import prefill_attention
@@ -112,9 +105,7 @@ def _torch_paged_prefill_attention(
     outputs = []
     query_start = 0
     block_size = key_cache.shape[1]
-    for batch_idx, (q_seq_len, kv_seq_len) in enumerate(
-        zip(q_seq_lens, kv_seq_lens)
-    ):
+    for batch_idx, (q_seq_len, kv_seq_len) in enumerate(zip(q_seq_lens, kv_seq_lens)):
         num_blocks = math.ceil(kv_seq_len / block_size)
         block_ids = block_table[batch_idx, :num_blocks].long()
         key = key_cache[block_ids].flatten(0, 1)[:kv_seq_len]
@@ -216,9 +207,7 @@ def test_paged_prefill_attention_mla_matches_torch(fai_causal_mask):
     block_table = torch.tensor([[2, 0], [3, 1]], dtype=torch.int32)
 
     query = _randn((sum(q_seq_lens), NUM_Q_HEADS, MLA_QK_HEAD_DIM))
-    key_cache = _randn(
-        (num_blocks, block_size, NUM_KV_HEADS, MLA_QK_HEAD_DIM)
-    )
+    key_cache = _randn((num_blocks, block_size, NUM_KV_HEADS, MLA_QK_HEAD_DIM))
     expected = _torch_paged_prefill_attention(
         query, key_cache, block_table, q_seq_lens, kv_seq_lens
     )
@@ -263,9 +252,6 @@ def test_paged_prefill_attention_mla_matches_torch(fai_causal_mask):
 
 
 def test_paged_prefill_attention_mla_graph_replay(fai_causal_mask):
-    if not aclgraph_use_torch_npu_update():
-        pytest.skip("FAI v2 graph update requires torch_npu >= 2.8.0.post1")
-
     torch.manual_seed(20260814)
     q_seq_lens = [2]
     capture_kv_seq_lens = [9]
@@ -273,9 +259,7 @@ def test_paged_prefill_attention_mla_graph_replay(fai_causal_mask):
     block_size = 128
     block_table = torch.tensor([[0]], dtype=torch.int32)
     query = _randn((sum(q_seq_lens), NUM_Q_HEADS, MLA_QK_HEAD_DIM))
-    key_cache = _randn(
-        (1, block_size, NUM_KV_HEADS, MLA_QK_HEAD_DIM)
-    )
+    key_cache = _randn((1, block_size, NUM_KV_HEADS, MLA_QK_HEAD_DIM))
     expected = _torch_paged_prefill_attention(
         query, key_cache, block_table, q_seq_lens, replay_kv_seq_lens
     )
@@ -319,32 +303,22 @@ def test_paged_prefill_attention_mla_graph_replay(fai_causal_mask):
 
     graph = torch.npu.NPUGraph()
     capture_stream = torch.npu.Stream()
-    set_graph_params({sum(q_seq_lens)})
-    graph_params = get_graph_params()
-    graph_params.is_mla = False
     try:
-        AscendGraphRunner.capturing = True
         with torch.npu.graph(
             graph,
             auto_dispatch_capture=True,
             stream=capture_stream,
         ):
             actual = paged_prefill_attention(**kwargs)
-        AscendGraphRunner.capturing = False
 
         graph.replay()
         graph.update(cpu_update_input=[{"actual_seq_kvlen": replay_kv_seq_lens}])
         torch.npu.synchronize()
 
-        assert graph_params.is_mla
         assert actual.data_ptr() == output.data_ptr()
-        torch.testing.assert_close(
-            actual.cpu().float(), expected, rtol=5e-3, atol=5e-3
-        )
+        torch.testing.assert_close(actual.cpu().float(), expected, rtol=5e-3, atol=5e-3)
     finally:
-        AscendGraphRunner.capturing = False
         graph.reset()
-        clear_graph_params()
 
 
 def test_decode_attention_mla_matches_torch():

--- a/tests/test_ascend_attention_precision.py
+++ b/tests/test_ascend_attention_precision.py
@@ -12,6 +12,14 @@ pytestmark = pytest.mark.lmdeploy
 if not torch.npu.is_available():
     pytest.skip("Ascend NPU is required", allow_module_level=True)
 
+from dlinfer.framework.lmdeploy_ext.cudagraph.ascend_cudagraph import (
+    AscendGraphRunner,
+    aclgraph_use_torch_npu_update,
+    clear_graph_params,
+    get_graph_params,
+    set_graph_params,
+)
+from dlinfer.ops import paged_prefill_attention
 from dlinfer.vendor.ascend.attention import decode_attention_mla
 from dlinfer.vendor.ascend.torch_npu_ops import prefill_attention
 
@@ -98,6 +106,37 @@ def _torch_decode_attention(query, key_cache, block_table, kv_seq_lens):
     return torch.stack(outputs)
 
 
+def _torch_paged_prefill_attention(
+    query, key_cache, block_table, q_seq_lens, kv_seq_lens
+):
+    outputs = []
+    query_start = 0
+    block_size = key_cache.shape[1]
+    for batch_idx, (q_seq_len, kv_seq_len) in enumerate(
+        zip(q_seq_lens, kv_seq_lens)
+    ):
+        num_blocks = math.ceil(kv_seq_len / block_size)
+        block_ids = block_table[batch_idx, :num_blocks].long()
+        key = key_cache[block_ids].flatten(0, 1)[:kv_seq_len]
+        value = key[..., :MLA_V_HEAD_DIM]
+        query_end = query_start + q_seq_len
+
+        q = query[query_start:query_end].float().transpose(0, 1)
+        k = _repeat_kv(key, NUM_Q_HEADS).float().transpose(0, 1)
+        v = _repeat_kv(value, NUM_Q_HEADS).float().transpose(0, 1)
+        scores = torch.matmul(q, k.transpose(-1, -2)) * MLA_SOFTMAX_SCALE
+
+        history_len = kv_seq_len - q_seq_len
+        q_positions = history_len + torch.arange(q_seq_len)
+        kv_positions = torch.arange(kv_seq_len)
+        causal_mask = kv_positions.unsqueeze(0) > q_positions.unsqueeze(1)
+        scores.masked_fill_(causal_mask.unsqueeze(0), float("-inf"))
+        outputs.append(torch.matmul(torch.softmax(scores, dim=-1), v).transpose(0, 1))
+        query_start = query_end
+
+    return torch.cat(outputs)
+
+
 def _assert_prefill_attention_matches_torch(
     qk_head_dim, value_head_dim, softmax_scale, causal_mask
 ):
@@ -165,6 +204,147 @@ def test_prefill_attention_mla_matches_torch(fai_causal_mask):
         softmax_scale=MLA_SOFTMAX_SCALE,
         causal_mask=fai_causal_mask,
     )
+
+
+def test_paged_prefill_attention_mla_matches_torch(fai_causal_mask):
+    torch.manual_seed(20260814)
+    q_seq_lens = [3, 2]
+    kv_seq_lens = [130, 77]
+    cumulative_q_seq_lens = [3, 5]
+    block_size = 128
+    num_blocks = 4
+    block_table = torch.tensor([[2, 0], [3, 1]], dtype=torch.int32)
+
+    query = _randn((sum(q_seq_lens), NUM_Q_HEADS, MLA_QK_HEAD_DIM))
+    key_cache = _randn(
+        (num_blocks, block_size, NUM_KV_HEADS, MLA_QK_HEAD_DIM)
+    )
+    expected = _torch_paged_prefill_attention(
+        query, key_cache, block_table, q_seq_lens, kv_seq_lens
+    )
+
+    query = query.to(DEVICE)
+    key_cache = key_cache.to(DEVICE)
+    value_cache = key_cache[..., :MLA_V_HEAD_DIM]
+    output = torch.empty(
+        (sum(q_seq_lens), NUM_Q_HEADS, MLA_V_HEAD_DIM),
+        dtype=DTYPE,
+        device=DEVICE,
+    )
+
+    actual = paged_prefill_attention(
+        query=query,
+        key=query[:, :NUM_KV_HEADS],
+        value=query[:, :NUM_KV_HEADS, :MLA_V_HEAD_DIM],
+        key_cache=key_cache,
+        value_cache=value_cache,
+        block_table=block_table.to(DEVICE),
+        block_size=block_size,
+        q_start_loc=None,
+        q_seq_len=torch.tensor(cumulative_q_seq_lens, dtype=torch.int32),
+        kv_seq_len=torch.tensor(kv_seq_lens, dtype=torch.int32),
+        cu_seq_lens_kv=None,
+        max_q_seq_len=max(q_seq_lens),
+        max_kv_seq_len=max(kv_seq_lens),
+        num_q_heads=NUM_Q_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        attn_mask=[fai_causal_mask],
+        softmax_scale=MLA_SOFTMAX_SCALE,
+        alibi_slopes=None,
+        attn_output=output,
+        kv_scales=None,
+        kv_zeros=None,
+        quant_bits=0,
+        head_size_v=MLA_V_HEAD_DIM,
+    )
+
+    assert actual.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(actual.cpu().float(), expected, rtol=5e-3, atol=5e-3)
+
+
+def test_paged_prefill_attention_mla_graph_replay(fai_causal_mask):
+    if not aclgraph_use_torch_npu_update():
+        pytest.skip("FAI v2 graph update requires torch_npu >= 2.8.0.post1")
+
+    torch.manual_seed(20260814)
+    q_seq_lens = [2]
+    capture_kv_seq_lens = [9]
+    replay_kv_seq_lens = [7]
+    block_size = 128
+    block_table = torch.tensor([[0]], dtype=torch.int32)
+    query = _randn((sum(q_seq_lens), NUM_Q_HEADS, MLA_QK_HEAD_DIM))
+    key_cache = _randn(
+        (1, block_size, NUM_KV_HEADS, MLA_QK_HEAD_DIM)
+    )
+    expected = _torch_paged_prefill_attention(
+        query, key_cache, block_table, q_seq_lens, replay_kv_seq_lens
+    )
+
+    query = query.to(DEVICE)
+    key_cache = key_cache.to(DEVICE)
+    output = torch.empty(
+        (sum(q_seq_lens), NUM_Q_HEADS, MLA_V_HEAD_DIM),
+        dtype=DTYPE,
+        device=DEVICE,
+    )
+    kwargs = dict(
+        query=query,
+        key=query[:, :NUM_KV_HEADS],
+        value=query[:, :NUM_KV_HEADS, :MLA_V_HEAD_DIM],
+        key_cache=key_cache,
+        value_cache=key_cache[..., :MLA_V_HEAD_DIM],
+        block_table=block_table.to(DEVICE),
+        block_size=block_size,
+        q_start_loc=None,
+        q_seq_len=torch.tensor(q_seq_lens, dtype=torch.int32),
+        kv_seq_len=torch.tensor(capture_kv_seq_lens, dtype=torch.int32),
+        cu_seq_lens_kv=None,
+        max_q_seq_len=max(q_seq_lens),
+        max_kv_seq_len=max(capture_kv_seq_lens),
+        num_q_heads=NUM_Q_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        attn_mask=[fai_causal_mask],
+        softmax_scale=MLA_SOFTMAX_SCALE,
+        alibi_slopes=None,
+        attn_output=output,
+        kv_scales=None,
+        kv_zeros=None,
+        quant_bits=0,
+        head_size_v=MLA_V_HEAD_DIM,
+    )
+
+    # Warm up allocations before capture, matching the model graph runner.
+    paged_prefill_attention(**kwargs)
+    torch.npu.synchronize()
+
+    graph = torch.npu.NPUGraph()
+    capture_stream = torch.npu.Stream()
+    set_graph_params({sum(q_seq_lens)})
+    graph_params = get_graph_params()
+    graph_params.is_mla = False
+    try:
+        AscendGraphRunner.capturing = True
+        with torch.npu.graph(
+            graph,
+            auto_dispatch_capture=True,
+            stream=capture_stream,
+        ):
+            actual = paged_prefill_attention(**kwargs)
+        AscendGraphRunner.capturing = False
+
+        graph.replay()
+        graph.update(cpu_update_input=[{"actual_seq_kvlen": replay_kv_seq_lens}])
+        torch.npu.synchronize()
+
+        assert graph_params.is_mla
+        assert actual.data_ptr() == output.data_ptr()
+        torch.testing.assert_close(
+            actual.cpu().float(), expected, rtol=5e-3, atol=5e-3
+        )
+    finally:
+        AscendGraphRunner.capturing = False
+        graph.reset()
+        clear_graph_params()
 
 
 def test_decode_attention_mla_matches_torch():

--- a/tests/test_ascend_attention_precision.py
+++ b/tests/test_ascend_attention_precision.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026, DeepLink. All rights reserved.
+
+import math
+
+import pytest
+import torch
+
+torch_npu = pytest.importorskip("torch_npu")
+
+pytestmark = pytest.mark.lmdeploy
+
+if not torch.npu.is_available():
+    pytest.skip("Ascend NPU is required", allow_module_level=True)
+
+from dlinfer.vendor.ascend.attention import decode_attention_mla
+from dlinfer.vendor.ascend.torch_npu_ops import prefill_attention
+
+DTYPE = torch.bfloat16
+DEVICE = torch.device("npu")
+FAI_CAUSAL_MASK_SIZE = 2048
+NUM_Q_HEADS = 16
+NUM_KV_HEADS = 1
+STANDARD_HEAD_DIM = 128
+STANDARD_SOFTMAX_SCALE = 1.0 / math.sqrt(STANDARD_HEAD_DIM)
+DENSE_NOPE_HEAD_DIM = 128
+DENSE_ROPE_HEAD_DIM = 64
+DENSE_QK_HEAD_DIM = DENSE_NOPE_HEAD_DIM + DENSE_ROPE_HEAD_DIM
+DENSE_V_HEAD_DIM = DENSE_NOPE_HEAD_DIM
+DENSE_SOFTMAX_SCALE = 1.0 / math.sqrt(DENSE_QK_HEAD_DIM)
+MLA_NOPE_HEAD_DIM = 512
+MLA_ROPE_HEAD_DIM = 64
+MLA_QK_HEAD_DIM = MLA_NOPE_HEAD_DIM + MLA_ROPE_HEAD_DIM
+MLA_V_HEAD_DIM = MLA_NOPE_HEAD_DIM
+# DeepSeekV2 keeps the scale of its pre-absorption 128 + 64 query head.
+MLA_SOFTMAX_SCALE = 1.0 / math.sqrt(128 + MLA_ROPE_HEAD_DIM)
+
+
+@pytest.fixture(scope="module")
+def fai_causal_mask():
+    """Build the fixed split-fuse mask expected by FAI sparse mode 3."""
+    return torch.triu(
+        torch.ones(
+            FAI_CAUSAL_MASK_SIZE,
+            FAI_CAUSAL_MASK_SIZE,
+            dtype=torch.int8,
+            device=DEVICE,
+        ),
+        diagonal=1,
+    )
+
+
+def _randn(shape):
+    return torch.randn(shape, dtype=torch.float32).to(DTYPE)
+
+
+def _repeat_kv(hidden_states, num_q_heads):
+    num_kv_heads = hidden_states.shape[1]
+    assert num_q_heads % num_kv_heads == 0
+    return hidden_states.repeat_interleave(num_q_heads // num_kv_heads, dim=1)
+
+
+def _torch_prefill_attention(query, key, value, seq_lens, softmax_scale):
+    outputs = []
+    start = 0
+    for seq_len in seq_lens:
+        end = start + seq_len
+        q = query[start:end].float().transpose(0, 1)
+        k = _repeat_kv(key[start:end], NUM_Q_HEADS).float().transpose(0, 1)
+        v = _repeat_kv(value[start:end], NUM_Q_HEADS).float().transpose(0, 1)
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) * softmax_scale
+        causal_mask = torch.triu(
+            torch.ones(seq_len, seq_len, dtype=torch.bool), diagonal=1
+        )
+        scores.masked_fill_(causal_mask, float("-inf"))
+        outputs.append(torch.matmul(torch.softmax(scores, dim=-1), v).transpose(0, 1))
+        start = end
+
+    return torch.cat(outputs)
+
+
+def _torch_decode_attention(query, key_cache, block_table, kv_seq_lens):
+    outputs = []
+    block_size = key_cache.shape[1]
+    for batch_idx, kv_seq_len in enumerate(kv_seq_lens):
+        num_blocks = math.ceil(kv_seq_len / block_size)
+        block_ids = block_table[batch_idx, :num_blocks].long()
+        key = key_cache[block_ids].flatten(0, 1)[:kv_seq_len]
+        value = key[..., :MLA_V_HEAD_DIM]
+
+        q = query[batch_idx].float()
+        k = _repeat_kv(key, NUM_Q_HEADS).float().transpose(0, 1)
+        v = _repeat_kv(value, NUM_Q_HEADS).float().transpose(0, 1)
+        scores = torch.matmul(q.unsqueeze(1), k.transpose(-1, -2))
+        scores = scores * MLA_SOFTMAX_SCALE
+        outputs.append(torch.matmul(torch.softmax(scores, dim=-1), v).squeeze(1))
+
+    return torch.stack(outputs)
+
+
+def _assert_prefill_attention_matches_torch(
+    qk_head_dim, value_head_dim, softmax_scale, causal_mask
+):
+    seq_lens = [112, 70, 31]
+    num_tokens = sum(seq_lens)
+
+    query = _randn((num_tokens, NUM_Q_HEADS, qk_head_dim))
+    key = _randn((num_tokens, NUM_KV_HEADS, qk_head_dim))
+    value = _randn((num_tokens, NUM_KV_HEADS, value_head_dim))
+    expected = _torch_prefill_attention(query, key, value, seq_lens, softmax_scale)
+
+    query = query.to(DEVICE)
+    key = key.to(DEVICE)
+    value = value.to(DEVICE)
+    seq_lens_tensor = torch.tensor(seq_lens, dtype=torch.int32)
+    max_seq_len = max(seq_lens)
+    output = torch.empty(
+        (num_tokens, NUM_Q_HEADS, value_head_dim), dtype=DTYPE, device=DEVICE
+    )
+
+    actual = prefill_attention(
+        query=query,
+        key=key,
+        value=value,
+        q_start_loc=None,
+        q_seq_len=seq_lens_tensor,
+        max_q_seq_len=max_seq_len,
+        num_q_heads=NUM_Q_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        attn_mask=[causal_mask],
+        softmax_scale=softmax_scale,
+        alibi_slopes=None,
+        attn_output=output,
+    )
+
+    assert actual.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(actual.cpu().float(), expected, rtol=5e-3, atol=5e-3)
+
+
+def test_prefill_attention_standard_matches_torch(fai_causal_mask):
+    torch.manual_seed(20260812)
+    _assert_prefill_attention_matches_torch(
+        qk_head_dim=STANDARD_HEAD_DIM,
+        value_head_dim=STANDARD_HEAD_DIM,
+        softmax_scale=STANDARD_SOFTMAX_SCALE,
+        causal_mask=fai_causal_mask,
+    )
+
+
+def test_prefill_attention_dense_matches_torch(fai_causal_mask):
+    torch.manual_seed(20260813)
+    _assert_prefill_attention_matches_torch(
+        qk_head_dim=DENSE_QK_HEAD_DIM,
+        value_head_dim=DENSE_V_HEAD_DIM,
+        softmax_scale=DENSE_SOFTMAX_SCALE,
+        causal_mask=fai_causal_mask,
+    )
+
+
+def test_prefill_attention_mla_matches_torch(fai_causal_mask):
+    torch.manual_seed(20260814)
+    _assert_prefill_attention_matches_torch(
+        qk_head_dim=MLA_QK_HEAD_DIM,
+        value_head_dim=MLA_V_HEAD_DIM,
+        softmax_scale=MLA_SOFTMAX_SCALE,
+        causal_mask=fai_causal_mask,
+    )
+
+
+def test_decode_attention_mla_matches_torch():
+    torch.manual_seed(20260813)
+    batch_size = 3
+    block_size = 128
+    num_blocks = 6
+    kv_seq_lens = [130, 77, 17]
+    block_table = torch.tensor(
+        [[4, 1], [3, 0], [5, 2]],
+        dtype=torch.int32,
+    )
+
+    query = _randn((batch_size, NUM_Q_HEADS, MLA_QK_HEAD_DIM))
+    key_cache = _randn((num_blocks, block_size, NUM_KV_HEADS, MLA_QK_HEAD_DIM))
+    expected = _torch_decode_attention(query, key_cache, block_table, kv_seq_lens)
+
+    query = query.to(DEVICE)
+    key_cache = key_cache.to(DEVICE)
+    output = torch.empty(
+        (batch_size, NUM_Q_HEADS, MLA_V_HEAD_DIM), dtype=DTYPE, device=DEVICE
+    )
+
+    actual = decode_attention_mla(
+        query=query,
+        key_cache=key_cache,
+        num_kv_heads=NUM_KV_HEADS,
+        num_q_heads=NUM_Q_HEADS,
+        scale_value=MLA_SOFTMAX_SCALE,
+        block_table=block_table.to(DEVICE),
+        kv_seq_len=torch.tensor(kv_seq_lens, dtype=torch.int32),
+        mla_vheadsize=MLA_V_HEAD_DIM,
+        attn_output=output,
+    )
+
+    assert actual.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(actual.cpu().float(), expected, rtol=5e-3, atol=5e-3)

--- a/tests/test_ascend_cudagraph_lifecycle.py
+++ b/tests/test_ascend_cudagraph_lifecycle.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026, DeepLink. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytest.importorskip("torch_npu")
+
+from dlinfer.framework.lmdeploy_ext.cudagraph.ascend_cudagraph import (
+    AscendGraphRunner,
+    _get_capture_batch_size_impl,
+)
+from lmdeploy.pytorch.backends.graph_runner import GraphRunnerMeta
+
+
+def test_capture_size_generation_is_pure():
+    _get_capture_batch_size_impl.cache_clear()
+    first = _get_capture_batch_size_impl(33)
+    _get_capture_batch_size_impl.cache_clear()
+    second = _get_capture_batch_size_impl(33)
+
+    assert first == second
+    assert first[-1] == 33
+
+
+def test_reset_preserves_configured_capture_sizes(monkeypatch):
+    runner = object.__new__(AscendGraphRunner)
+    runner._runner_meta = GraphRunnerMeta(padding_batch_size=16)
+    runner._runner_map = {}
+    runner.graph_pool_handle = object()
+    runner.cache_config = SimpleNamespace(
+        max_batches=32,
+        cudagraph_capture_batch_sizes=[1, 4, 16, 32],
+    )
+    monkeypatch.setattr(torch.npu, "empty_cache", lambda: None)
+
+    before_reset = runner.get_capture_batch_sizes().copy()
+    runner.reset()
+    after_reset = runner.get_capture_batch_sizes().copy()
+
+    assert runner.get_meta().padding_batch_size is None
+    assert runner.graph_pool_handle is None
+    assert before_reset == after_reset == [1, 4, 16, 32]


### PR DESCRIPTION
# PR 改动说明

## 背景

Ascend Attention 之前仍有多条 ATB 实现，包括 prefill、Dense paged decode 和
MLA paged decode。为了支持 DeepSeek-V2 MLA 以及统一 eager/graph 行为，本 PR
将相关路径迁移到 torch-npu FIA/FIA v2，并补齐 MLA paged prefill。

CUDAGraph 同时还维护了两套动态参数更新机制：

1. FIA/FIA v2 配合 `torch.npu.NPUGraph.update()`；
2. ATB paged attention 配合 graph-task handle、event 和模块级
   `GraphParams`。

旧 ATB graph 路径通过 `_graph_params` 在 Attention kernel 和 Graph Runner 之间
传递 Tensor、task handle、event 以及 MLA 标记；capture-size 计算函数还通过
副作用初始化这些资源。这会造成以下问题：

- graph 资源生命周期和 capture-size 配置耦合；
- `_graph_params` 持有 KV cache 等 Tensor 引用，rollout reset 时容易残留旧资源；
- 相同 `max_batches` 命中 `lru_cache` 时，初始化副作用不会再次执行，不利于 RL
  rollout 后的 re-capture；
- `GraphParams.is_mla` 依赖算子 capture 时写入全局状态；
- 新旧 Attention 路径长期并存，增加维护和精度验证成本。

本 PR 完成 Attention 算子迁移、序列长度参数优化和 Graph 生命周期重构，并将
运行时基线固定到支持 `NPUGraph.update()` 的 torch/torch-npu 版本。

## 主要改动

### 1. Prefill Attention 从 ATB 迁移到 FIA

普通 prefill 使用 `torch_npu.npu_fused_infer_attention_score` 替换
`_npu_flash_attention`/`_npu_flash_attention_unpad`：

- 常规语言模型使用 `TND` layout；
- 无 mask 的视觉 Attention 根据输入形状支持 `TND` 或 `BSH`；
- 有 causal mask 的标准 Attention、GQA 和 MLA 使用固定 split-fuse mask 与
  `sparse_mode=3`；
- 无 mask 路径使用 `sparse_mode=0`；
- FIA 输出复制回预分配的 `attn_output`，保持现有接口和内存复用语义。

当 `query/key` 的 head dim 大于 value head dim 时，按照 MLA 语义切分：

```text
Q = [q_nope, q_rope]
K = [k_nope, k_rope]
```

NoPE 部分作为 FIA 主输入，RoPE 部分通过 `query_rope`/`key_rope` 独立传入。
prefill 路径会对切分后的 Q/K NoPE 和 RoPE Tensor 做必要的 contiguous，满足
FIA 输入要求。

### 2. Dense/MLA decode 迁移到 FIA/FIA v2

Dense paged decode 使用：

```text
npu_fused_infer_attention_score
input_layout = TND
sparse_mode = 0
block_table + block_size
```

MLA paged decode 使用：

```text
npu_fused_infer_attention_score_v2
input_layout = BNSD_NBSD
sparse_mode = 0
query_rope/key_rope
block_table + block_size
```

MLA decode 会将 Q 拆为 NoPE/RoPE，将 paged key cache 从
`[block, block_size, kv_head, dim]` 转为 FIA v2 所需的
`[block, kv_head, block_size, dim]`，并将 FIA v2 输出恢复到原有
`attn_output` layout。

### 3. 新增 MLA paged prefill

`paged_prefill_attention` 新增可选参数 `head_size_v`，并通过公共 LLM API 传入
vendor 实现。Camb/MACA 同步接收该参数以保持 vendor 接口一致。

Ascend 通过 `key_cache.shape[-1] != value_cache.shape[-1]` 识别 MLA cache：

- latent K/V 与 RoPE K 分开传给 FIA v2；
- paged KV cache 转为 `[block, kv_head, block_size, dim]`；
- 使用 `TND_NTD` layout、`sparse_mode=3` 和 causal mask；
- 强制 `block_table` 为 `int32`；
- 兼容预分配 `attn_output` 和直接返回 output 两种调用方式。

非 MLA paged prefill 仍使用 FIA，保留 `TND`、paged block table 和
`sparse_mode=3`。

### 4. 移除 Attention 热路径中的 `.tolist()`

以下 FIA/FIA v2 参数改为直接传递 Tensor：

```text
actual_seq_lengths
actual_seq_lengths_kv
actual_seq_qlen
actual_seq_kvlen
```

避免每层 Attention 执行时把序列长度同步到 CPU 并构造 Python list。
`NPUGraph.update()` 的 MLA `cpu_update_input` 仍按 torch-npu 接口要求使用 list；
它属于 graph replay 更新元信息，不是每层 FIA 算子调用。

### 5. 固定 torch/torch-npu 运行时版本

新增集中式校验，要求：

```text
torch >= 2.8.0
torch-npu >= 2.8.0.post1
torch 与 torch-npu 使用相同的 major.minor 版本
torch.npu.NPUGraph.update 可用
```

校验在 Ascend vendor 初始化时执行。配套 LMDeploy 改动也会在 Ascend backend
初始化时显式调用。运行时不满足要求会直接抛出带版本信息的 `RuntimeError`，
不再静默退回旧 ATB 路径。

依赖范围同步调整为：

```text
torch>=2.8.0,<2.10.0
torch-npu>=2.8.0.post1,<2.10.0
torchvision>=0.23.0,<0.25.0
```

DICP 版本识别同步增加当前环境使用的 torch 2.9.0，依赖中增加
`packaging` 用于可靠解析版本字符串。

### 6. 删除旧 ATB graph-task Attention 路径

删除以下全局状态和辅助函数：

```text
GraphParams
_graph_params
_graph_capture_sizes
set_graph_params()
get_graph_params()
clear_graph_params()
update_attn_params()
update_decode_attention_params()
update_decode_attention_mla_params()
```

同时删除 `graph_task_group_*`、`graph_task_update_*`、
`_npu_paged_attention` 和 `_npu_paged_attention_mla` 的旧 graph 路径。

重构后的整体算子关系为：

```text
Prefill          -> npu_fused_infer_attention_score
Dense decode     -> npu_fused_infer_attention_score
MLA decode       -> npu_fused_infer_attention_score_v2
MLA paged prefill -> npu_fused_infer_attention_score_v2
Graph replay     -> torch.npu.NPUGraph.update
```

### 7. 显式传递 MLA 模型信息

LMDeploy Ascend backend 在构造 Graph Runner 时根据模型配置判断：

```python
is_mla = model_config.k_head_dim != model_config.v_head_dim
```

`is_mla` 通过构造参数传递给 `AscendGraphRunner` 和
`AscendSingleGraphRunner`。Graph replay 根据实例级字段选择更新参数：

```text
Dense: actual_seq_lengths_kv = Tensor
MLA:   actual_seq_kvlen = list
```

Attention kernel 不再通过 `GraphParams.is_mla` 向 Graph Runner 回传模型类型。

### 8. 分离 capture-size 策略和图资源生命周期

`_get_capture_batch_size_impl(max_batches)` 现在是纯函数，只负责返回 capture
sizes，不再初始化任何图资源。

`AscendGraphRunner.get_capture_batch_sizes()` 会优先使用
`CacheConfig.cudagraph_capture_batch_sizes`，未显式配置时才使用 Ascend 默认
策略。因此 capture sizes 可以随 `CacheConfig` 跨 rollout 保存，而 NPUGraph、
output buffer 和 Tensor 引用仍在 reset 时释放。

### 9. 修正 Graph Runner reset/capture 生命周期

- `AscendGraphRunner.reset()` 先调用基类 reset，清除 rollout 局部的
  `padding_batch_size`；
- 释放所有 single graph runner、output buffer、runner map 和 graph pool 引用；
- 不清除 `CacheConfig` 中的 capture-size 配置；
- capture 使用 `try/finally` 恢复 `AscendGraphRunner.capturing`，避免异常后状态
  残留。

`AscendGraphRunner.capturing` 仍然保留，因为 MoE graph capture 路径仍需要该
标记；Attention 已不再依赖它维护全局状态。

## 跨仓改动与合入顺序

该重构同时涉及 DLINFER 和 LMDeploy。

DLINFER：

- 提供新的 `AscendGraphRunner(..., is_mla=False)` 接口；
- 将 prefill、Dense decode、MLA decode 和 MLA paged prefill 统一到 FIA/FIA v2；
- 为 MLA paged prefill 增加 `head_size_v` vendor 接口；
- 删除 FIA 算子序列长度参数上不必要的 `.tolist()`；
- 固定 torch/torch-npu 最低版本并增加 torch 2.9 DICP 识别；
- 删除旧 GraphParams/ATB graph-task 路径；
- 增加生命周期和 Attention 精度测试。

LMDeploy：

- 根据 `ModelConfig` 判断 `is_mla` 并传给 DLINFER Graph Runner；
- 初始化 Ascend backend 时显式执行版本校验；
- 复用按设备缓存的固定 FIA causal mask，避免每次 Attention 执行时分配。

建议先合入 DLINFER，再合入 LMDeploy 配套修改，或者在两个 PR 中相互添加依赖
链接。LMDeploy 新调用方式依赖 DLINFER Graph Runner 的 `is_mla` 参数。

## 兼容性变化

这是一次有意的运行时兼容性收紧：

- 不再支持 `torch<2.8.0`；
- 不再支持 `torch-npu<2.8.0.post1`；
- 不再提供旧 ATB graph-task Attention fallback；
- torch/torch-npu major.minor 不一致时直接报错；
- eager 和 graph 模式均使用 FIA/FIA v2 Attention 路径；
- 删除 Ascend310P 带 mask 场景的 `_npu_prompt_flash_attention` prefill
  fallback；带 mask 的 `prefill_attention` 当前仅支持 Ascend910 系列。无 mask
  的 FIA 视觉 Attention 分支不受该限制。

当前依赖上限仍保留 `<2.10.0`，torch 2.10 及更高版本需要验证后再放开。

## 测试

测试环境：

```text
Ascend A3
torch 2.9.0+cpu
torch-npu 2.9.0
```

运行前加载：

```bash
source /afs-weights/wangqing/deepseekv2_dev/ascend_env.sh
```

单元和算子测试：

```bash
pytest -q \
  tests/test_ascend_cudagraph_lifecycle.py \
  tests/test_ascend_attention_precision.py
```

结果：

```text
8 passed
```

覆盖 capture-size 纯函数、reset 后配置保留、标准/Dense/MLA prefill、MLA paged
prefill、MLA FIA v2 graph replay 动态 KV 长度更新和 MLA decode 精度。版本校验
通过当前 torch 2.9.0/torch-npu 2.9.0 环境的 vendor 导入和两项端到端模型测试
覆盖。

端到端回归：

```text
DeepSeek-V2-Lite MLA graph
  tp=2, batch size=32
  graph capture/replay 成功
  32 路请求完成生成
  exit code=0

Qwen3.5-35B Dense graph
  tp=2
  完成 batch size 64 -> 1 的全部 graph warmup/capture
  Dense decode graph replay 成功
  生成 10 token
  exit code=0
```

静态检查：

```text
Black check: passed
py_compile: passed
git diff --check: passed
旧 GraphParams/ATB Attention 符号扫描: no matches
```

## 风险与后续验证

已覆盖：

- 标准 Attention、QK/V head dim 不同的 Dense Attention 和 MLA prefill 精度；
- MLA paged prefill 和 MLA decode 精度；
- DeepSeek MLA 和 Qwen Dense 均完成真实 graph capture/replay；
- 当前 torch 2.9.0/torch-npu 2.9.0 能通过运行时校验；
- reset 后 capture-size 配置保留行为有回归测试；
- Attention Python 路径没有残留旧 GraphParams/ATB 调用。

仍建议在真实 RL 环境中进行多轮：

```text
capture -> rollout -> sleep/reset -> 更新权重 -> wakeup -> re-capture
```

重点检查每轮 capture sizes、旧权重/KV cache 引用、NPU 显存增长和 re-capture
输出精度。

## Reviewer 建议重点关注

1. `model_config.k_head_dim != model_config.v_head_dim` 是否覆盖当前所有 MLA 模型；
2. MLA prefill/decode 的 NoPE/RoPE 切分、contiguous 和 KV cache layout；
3. `sparse_mode=3` 与固定 split-fuse causal mask 是否覆盖各类 prefill 输入；
4. FIA/FIA v2 序列长度参数直接传 Tensor 的 torch-npu 接口兼容性；
5. Dense/MLA `NPUGraph.update()` 参数名和数据类型是否符合 torch-npu 接口；
6. `reset()` 是否完整释放 rollout 局部资源并保留 capture-size 配置；
7. Ascend310P prefill fallback 删除是否符合当前设备支持策略；
8. DLINFER 与 LMDeploy 两个 PR 的依赖和合入顺序。

## 本 PR 范围

本 PR 已整合以下连续改动，应作为一个完整功能链进行 review：

1. prefill、Dense decode 和 MLA decode 迁移到 FIA/FIA v2；
2. prefill 使用 `sparse_mode=3` 和固定 causal mask；
3. 新增 MLA paged prefill 及 `head_size_v` vendor 接口；
4. 删除 FIA 算子参数上不必要的 `.tolist()`；
5. 删除旧 ATB Attention 路径；
6. 固定 torch/torch-npu 最低版本并支持 torch 2.9；
7. 删除旧 GraphParams/graph-task capture 更新机制并修正 RL 生命周期。

其中 Attention 迁移依赖 FIA 能力，Graph 路径统一又依赖
`torch-npu>=2.8.0.post1` 的 `NPUGraph.update()`，因此版本约束属于该功能链的一
部分，不再作为独立 PR 拆分。

## 最终精度测试
<img width="839" height="320" alt="截图 2026-08-20 16-55-27" src="https://github.com/user-attachments/assets/b77c44c0-02cb-40f1-acb5-78e96889c631" />

